### PR TITLE
add coding: sign into Rakefile for non-ASCII characters

### DIFF
--- a/lib/motion/project/app.rb
+++ b/lib/motion/project/app.rb
@@ -99,6 +99,7 @@ module Motion; module Project
           App.log 'Create', File.join(app_name, 'Rakefile')
           File.open('Rakefile', 'w') do |io|
             io.puts <<EOS
+# -*- coding: utf-8 -*-
 $:.unshift(\"#{$motion_libdir}\")
 require 'motion/project'
 


### PR DESCRIPTION
I need to write non-ASCII characters into Rakefile when I change codesign_certificate because my certificate name includes non-ASCII characters.
