### PR TITLE
Added the possibility to have - and _ in the project name

### DIFF
--- a/lib/motion/project/app.rb
+++ b/lib/motion/project/app.rb
@@ -77,7 +77,7 @@ module Motion; module Project
       end
 
       def create(app_name)
-        unless app_name.match(/^[a-zA-Z\d\s]+$/)
+        unless app_name.match(/^[\w\s-]+$/)
           fail "Invalid app name"
         end
     


### PR DESCRIPTION
I don't know if there's any issue with apps with those characters in the AppStore, but that can later be changed in the Rakrefile. I found it annoying not being able to create projects with multi-word names.
