### PR TITLE
add cpu_types for iOS SDK 4.3

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -361,10 +361,11 @@ EOS
     end
 
     def archs(platform)
+      @cpu_types << :i386
       sdk_archs = Dir.glob(File.join(datadir, platform, '*.bc')).map do |path|
         path.scan(/kernel-(.+).bc$/)[0][0]
       end
-      sdk_archs & @cpu_types.map{ |cpu| cpu.to_s }
+      sdk_archs & @cpu_types.uniq.map{ |cpu| cpu.to_s }
     end
 
     def arch_flags(platform)


### PR DESCRIPTION
When use the iOS SDK 4.3, App will be linked ARMv6 and ARMv7 binary.
However, link error ocurrs when use static libraries which only contain ARMv7 (or ARMv6) as vendor library.

```
$ rake device
     Build ./build/iPhoneOS-4.3-Development
     Build vendor/foo
   Compile ./app/app_delegate.rb
    Create ./build/iPhoneOS-4.3-Development/LibTest.app
      Link ./build/iPhoneOS-4.3-Development/LibTest.app/LibTest
ld: in /Users/watson/Documents/RubyMotion/LibTest/vendor/foo/libfoo.a, file is universal but does not contain a(n) armv6 slice for architecture armv6
collect2: ld returned 1 exit status
lipo: can't open input file: /var/folders/1z/ff7x15cj7vb24rl38ty0y52w0000gn/T//ccq4Hey1.out (No such file or directory)
rake aborted!
Command failed with status (1): [/Applications/Xcode.app/Contents/Developer...]

Tasks: TOP => device => archive:development
(See full trace by running task with --trace)
```

So, we need to specify cpu types for using its library.
