### PR TITLE
clear $RUBYOPT when calling gen_bridge_metadata

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -592,8 +592,7 @@ EOS
       a = sdk_version.scan(/(\d+)\.(\d+)/)[0]
       sdk_version_headers = ((a[0].to_i * 10000) + (a[1].to_i * 100)).to_s
       extra_flags = OSX_VERSION >= 10.7 ? '--no-64-bit' : ''
-
-      sh "/usr/bin/gen_bridge_metadata --format complete #{extra_flags} --cflags \"-isysroot #{sdk_path} -miphoneos-version-min=#{sdk_version} -D__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__=#{sdk_version_headers} -I. #{includes.join(' ')}\" #{headers.join(' ')} -o \"#{bs_file}\""
+      sh "RUBYOPT='' /usr/bin/gen_bridge_metadata --format complete #{extra_flags} --cflags \"-isysroot #{sdk_path} -miphoneos-version-min=#{sdk_version} -D__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__=#{sdk_version_headers} -I. #{includes.join(' ')}\" #{headers.join(' ')} -o \"#{bs_file}\""
     end
   end
 end; end


### PR DESCRIPTION
When I use bundler, calling `gen_bridge_metadata` in a rake task(with `sh` method) causes errors like below.

```
Could not find foo-x.xx.x in any of the sources
Run `bundle install` to install missing gems.
rake aborted!
Command failed with status (7): [/usr/bin/gen_bridge_metadata --format comp...]
```

Because `gen_bridge_metadata` is a ruby script and Bundler sets a environment variable `RUBYOPT`, this causes the problem.

So, I needed to clear `RUBYOPT` when I call `gen_bridge_metadata` temporary.
