### PR TITLE
Read from user defined Rakefile

### DIFF
--- a/lib/motion/project/app.rb
+++ b/lib/motion/project/app.rb
@@ -103,8 +103,8 @@ module Motion; module Project
             File.open(rakefileTemplate, 'r') do |src|
               File.open('Rakefile', 'w') do |dest|
                 source = src.read
-                source = source.gsub(/\#{\$motion_libdir}/){"#{$motion_libdir}"}
-                source = source.gsub(/\#{app_name}/){"#{app_name}"}
+                source = source.gsub(/\#\{\$motion_libdir\}/){"#{$motion_libdir}"}
+                source = source.gsub(/\#\{app_name\}/){"#{app_name}"}
                 dest.write(source)
               end
             end


### PR DESCRIPTION
Currently, Rakefile that created by motion create is fixed.
we always add TestFlight setting, some require statement, etc,,, to generated Rakefile each motion create.
it's a pain.

I thought that motion create use my defined Rakefile!

on this commit, Read Rakefile placed in ~/.rubymotion/

in Rakefile, #{$motion_libdir} and #{app_name} are occurred then replace to their variable's values.
