### PR TITLE
restore inclusion of specs_dir sub-directories

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -325,18 +325,18 @@ EOS
     def spec_files
       @spec_files ||= begin
         # Core library + core helpers.
-        files = Dir.chdir(File.join(File.dirname(__FILE__), '..')) { (['spec.rb'] + Dir.glob(File.join('spec', 'helpers', '*.rb'))).map { |x| File.expand_path(x) } }
+        core = Dir.chdir(File.join(File.dirname(__FILE__), '..')) { (['spec.rb'] + Dir.glob(File.join('spec', 'helpers', '*.rb'))).map { |x| File.expand_path(x) } }
         # Project helpers.
-        files += Dir.glob(File.join(specs_dir, 'helpers', '*.rb'))
+        helpers = Dir.glob(File.join(specs_dir, 'helpers', '*.rb'))
         # Project specs.
-        specs = Dir.glob(File.join(specs_dir, '**', '*.rb'))
+        specs = Dir.glob(File.join(specs_dir, '**', '*.rb')) - helpers
         if files_filter = ENV['files']
           # Filter specs we want to run. A filter can be either the basename of a spec file or its path.
           files_filter = files_filter.split(',')
           files_filter.map! { |x| File.exist?(x) ? File.expand_path(x) : x }
           specs.delete_if { |x| !files_filter.include?(File.expand_path(x)) and !files_filter.include?(File.basename(x, '.rb')) }
         end
-        files + specs
+        core + helpers + specs
       end
     end
 


### PR DESCRIPTION
It looks like 5a37c3df38b7e3a759b0897e6c1774a7ed83f488 removed the `**`
from the pattern used to generate the specs array. This has the effect
of only running specs located directly in the `specs_dir` directory.

For example, with the following directory structure, only `foo_spec.rb`
would be run with an invocation of `rake spec`.

spec/foo_spec.rb
spec/bar/bar_spec.rb

This patch restores the `**` passed to `Dir.glob` and also uses
`Dir.join` for generation of the path to the spec helpers directory.
