### PR TITLE
Bundler/Gemfile errors

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -1,15 +1,15 @@
 # Copyright (c) 2012, HipByte SPRL and contributors
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
 #    list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -40,10 +40,10 @@ if $?.exitstatus == 2
 end
 
 begin
-  require 'bundler/setup'
+  require 'bundler'
   Bundler.require
 rescue LoadError
-rescue NoMethodError
+rescue Bundler::GemfileNotFound
 end
 
 desc "Build the project, then run the simulator"
@@ -77,7 +77,7 @@ task :simulator => ['build:simulator'] do
       if File.basename(app_bundle) == File.basename(app)
         rm_rf File.dirname(app_bundle)
         break
-      end  
+      end
     end
   end
 


### PR DESCRIPTION
On 1.16 (untested on previous versions): If the user has the Bundler gem installed, but no Gemfile in their project, then an unhanded NoMethodError is thrown when doing `Bundle.require`

On a fresh project under 1.16 (using `motion create foo`):

Without Bundler installed:

```
$ rake -T
# Works!
```

With Bundler installed, and a Gemfile in the project:

```
$ rake -T
# Works!
```

With Bundler installed, but no Gemfile:

```
$ rake -T --trace

rake aborted!
private method `require' called for Bundler:Module
/Library/RubyMotion/lib/motion/project.rb:44:in `<top (required)>'
/usr/local/Cellar/rbenv/0.3.0/versions/1.9.3-p194-perf/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
/usr/local/Cellar/rbenv/0.3.0/versions/1.9.3-p194-perf/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
/Users/dylan/foo/Rakefile:3:in `<top (required)>'
```

This pull request simply catches the `NoMethodError` and moves on, continuing to run without Bundler.
