### PR TITLE
Add `rake spec:units` and `rake spec:functionals`

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -138,10 +138,26 @@ namespace :archive do
   end
 end
 
-desc "Run the test/spec suite"
-task :spec do
-  App.config.spec_mode = true
-  Rake::Task["simulator"].invoke
+desc "Run entire test/spec suite"
+task :spec => ['spec:all']
+
+namespace :spec do
+  task :all do
+    App.config.spec_mode = true
+    Rake::Task["simulator"].invoke
+  end
+
+  desc "Run unit test/spec suite"
+  task :units do
+    App.config.spec_mode = :units
+    Rake::Task["simulator"].invoke
+  end
+
+  desc "Run functional test/spec suite"
+  task :functionals do
+    App.config.spec_mode = :functionals
+    Rake::Task["simulator"].invoke
+  end
 end
 
 desc "Deploy on the device"

--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -49,10 +49,10 @@ module Motion; module Project
 
     variable :files, :xcode_dir, :sdk_version, :deployment_target, :frameworks,
       :weak_frameworks, :libs, :delegate_class, :name, :build_dir,
-      :resources_dir, :specs_dir, :identifier, :codesign_certificate,
-      :provisioning_profile, :device_family, :interface_orientations, :version,
-      :short_version, :icons, :prerendered_icon, :background_modes, :seed_id,
-      :entitlements, :fonts, :status_bar_style, :motiondir
+      :resources_dir, :specs_dir, :unit_specs_dir, :functional_specs_dir,
+      :identifier, :codesign_certificate, :provisioning_profile, :device_family,
+      :interface_orientations, :version, :short_version, :icons, :prerendered_icon,
+      :background_modes, :seed_id, :entitlements, :fonts, :status_bar_style, :motiondir
 
     attr_accessor :spec_mode
 
@@ -67,7 +67,7 @@ module Motion; module Project
       @name = 'Untitled'
       @resources_dir = File.join(project_dir, 'resources')
       @build_dir = File.join(project_dir, 'build')
-      @specs_dir = File.join(project_dir, 'spec')
+      self.specs_dir = File.join(project_dir, 'spec')
       @device_family = :iphone
       @bundle_signature = '????'
       @interface_orientations = [:portrait, :landscape_left, :landscape_right]
@@ -322,6 +322,24 @@ EOS
       end
     end
 
+    def specs_dir=(_specs_dir)
+      @specs_dir = _specs_dir
+      @unit_specs_dir = File.join(@specs_dir, 'unit')
+      @functional_specs_dir = File.join(@specs_dir, 'functional')
+      @specs_dir
+    end
+
+    def current_specs_dir
+      case spec_mode
+      when :units
+        @unit_specs_dir
+      when :functionals
+        @functional_specs_dir
+      else
+        @specs_dir
+      end
+    end
+
     def spec_files
       @spec_files ||= begin
         # Core library + core helpers.
@@ -329,7 +347,7 @@ EOS
         # Project helpers.
         helpers = Dir.glob(File.join(specs_dir, 'helpers', '*.rb'))
         # Project specs.
-        specs = Dir.glob(File.join(specs_dir, '**', '*.rb')) - helpers
+        specs = Dir.glob(File.join(current_specs_dir, '**', '*.rb')) - helpers
         if files_filter = ENV['files']
           # Filter specs we want to run. A filter can be either the basename of a spec file or its path.
           files_filter = files_filter.split(',')


### PR DESCRIPTION
Running the functional tests and unit tests together is kind of a pain since functionals usually take much longer (animations have to complete, etc).

These could be set on a project-by-project basis but I thought it'd be nice to have a sensible default. Took the nomenclature from Rails-land.

By default, these will run the tests in `"#{app.specs_dir}/unit"` and `"#{app.specs_dir}/functional"`, but those can be overridden by setting `app.unit_specs_dir` and `app.functional_specs_dir`. `rake spec` functions like normal.
