### PR TITLE
location specific taps

### DIFF
--- a/lib/motion/spec/helpers/ui.rb
+++ b/lib/motion/spec/helpers/ui.rb
@@ -323,8 +323,6 @@ module Bacon
         touches  = options[:touches] || 1
         location = _coerce_location_to_point(view, options[:at], false) || view.superview.convertPoint(view.center, toView:nil)
 
-        location = view.superview.convertPoint(view.center, toView:window)
-
         _event_generator.sendTaps(taps,
                          location:location,
               withNumberOfTouches:touches,

--- a/test/bacon-ui/spec/simple_gestures_spec.rb
+++ b/test/bacon-ui/spec/simple_gestures_spec.rb
@@ -70,10 +70,12 @@ class SmallControlsViewController < UIViewController
 
   attr_reader :tapRecognizer
   attr_reader :tappedLocationInWindow
+  attr_reader :tappedLocationInTappableView
   def handleTap(recognizer)
     @tappableView.text = "Taps: #{recognizer.numberOfTapsRequired}"
     @tapRecognizer = recognizer
     @tappedLocationInWindow = recognizer.locationInView(nil)
+    @tappedLocationInTappableView = recognizer.locationInView(@tappableView)
   end
 end
 
@@ -91,6 +93,58 @@ describe "Bacon::Functional::API, concerning one-shot gestures" do
     highlight_touches!
     view = tap("Tappable view")
     controller.tappedLocationInWindow.should == view.superview.convertPoint(view.center, toView:nil)
+  end
+
+  it "taps at the :top_left of a view" do
+    highlight_touches!
+    view = tap("Tappable view", :at => :top_left)
+    controller.tappedLocationInTappableView.x.should < view.frame.size.width / 2
+    controller.tappedLocationInTappableView.y.should < view.frame.size.height / 2
+  end
+
+  it "taps at the :top of a view" do
+    highlight_touches!
+    view = tap("Tappable view", :at => :top)
+    controller.tappedLocationInTappableView.y.should < view.frame.size.height / 2
+  end
+
+  it "taps at the :top_right of a view" do
+    highlight_touches!
+    view = tap("Tappable view", :at => :top_right)
+    controller.tappedLocationInTappableView.x.should > view.frame.size.width / 2
+    controller.tappedLocationInTappableView.y.should < view.frame.size.height / 2
+  end
+
+  it "taps at the :right of a view" do
+    highlight_touches!
+    view = tap("Tappable view", :at => :right)
+    controller.tappedLocationInTappableView.x.should > view.frame.size.width / 2
+  end
+
+  it "taps at the :bottom_right of a view" do
+    highlight_touches!
+    view = tap("Tappable view", :at => :bottom_right)
+    controller.tappedLocationInTappableView.x.should > view.frame.size.width / 2
+    controller.tappedLocationInTappableView.y.should > view.frame.size.height / 2
+  end
+
+  it "taps at the :bottom of a view" do
+    highlight_touches!
+    view = tap("Tappable view", :at => :bottom)
+    controller.tappedLocationInTappableView.y.should > view.frame.size.height / 2
+  end
+
+  it "taps at the :bottom_left of a view" do
+    highlight_touches!
+    view = tap("Tappable view", :at => :bottom_left)
+    controller.tappedLocationInTappableView.x.should < view.frame.size.width / 2
+    controller.tappedLocationInTappableView.y.should > view.frame.size.height / 2
+  end
+
+  it "taps at the :left of a view" do
+    highlight_touches!
+    view = tap("Tappable view", :at => :left)
+    controller.tappedLocationInTappableView.x.should < view.frame.size.width / 2
   end
 
   #it "taps at a specific point in window coordinates" do


### PR DESCRIPTION
I was testing a `UIStepper` today, and taps weren't going to the area of the view specified by the `:at` parameter. It looks like the `:at`-based location is being overwritten. This commit adds some tests for the various `:at` options and removes the statement that was overwriting the more specific location.

@alloy - I assume you'll want to look this over.
