### PR TITLE
Add "-fobjc-arc" for linker flag when deployment target is 4.3

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -425,7 +425,9 @@ EOS
     end
 
     def ldflags(platform)
-      common_flags(platform)
+      ldflags = common_flags(platform)
+      ldflags << " -fobjc-arc" if deployment_target < '5.0'
+      ldflags
     end
 
     def bundle_name


### PR DESCRIPTION
To use ARC-enabled libraries (e.g. [SVPullToRefresh](https://github.com/samvermette/SVPullToRefresh)) on iOS 4.3 device, this flag seems to be needed.

http://stackoverflow.com/questions/7967415/could-i-build-a-arc-framework-and-use-it-in-a-non-arc-project
