### PR TITLE
compile xib/storyboard files in nested directories

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -392,8 +392,8 @@ EOS
       # Compile IB resources.
       if File.exist?(config.resources_dir)
         ib_resources = []
-        ib_resources.concat((Dir.glob(File.join(config.resources_dir, '*.xib')) + Dir.glob(File.join(config.resources_dir, '*.lproj', '*.xib'))).map { |xib| [xib, xib.sub(/\.xib$/, '.nib')] })
-        ib_resources.concat(Dir.glob(File.join(config.resources_dir, '*.storyboard')).map { |storyboard| [storyboard, storyboard.sub(/\.storyboard$/, '.storyboardc')] })
+        ib_resources.concat((Dir.glob(File.join(config.resources_dir, '**', '*.xib')) + Dir.glob(File.join(config.resources_dir, '*.lproj', '*.xib'))).map { |xib| [xib, xib.sub(/\.xib$/, '.nib')] })
+        ib_resources.concat(Dir.glob(File.join(config.resources_dir, '**', '*.storyboard')).map { |storyboard| [storyboard, storyboard.sub(/\.storyboard$/, '.storyboardc')] })
         ib_resources.each do |src, dest|
           if !File.exist?(dest) or File.mtime(src) > File.mtime(dest)
             App.info 'Compile', src


### PR DESCRIPTION
Currently, nib and storyboard files within the resources directory need to be at the base directory level, or they don't get added to the final app. The directories that they are contained in do, but the nib/storyboard files themselves do not.

This request just adds subdirectories to the glob.
