### PR TITLE
Colorize TestUnit spec output

### DIFF
--- a/lib/motion/spec.rb
+++ b/lib/motion/spec.rb
@@ -51,23 +51,37 @@ module Bacon
   end
 
   module TestUnitOutput
+    GREEN = "\033[0;32m"
+    RED   = "\033[0;31m"
+    RESET = "\033[00m"
+
     def handle_specification_begin(name); end
     def handle_specification_end        ; end
 
     def handle_requirement_begin(description) end
     def handle_requirement_end(error)
       if error.empty?
-        print "."
+        print "#{GREEN}.#{RESET}"
       else
-        print error[0..0]
+        print "#{RED}#{error[0..0]}#{RESET}"
       end
     end
 
     def handle_summary
-      puts "", "Finished in #{Time.now - @timer} seconds."
-      puts ErrorLog  if Backtraces
-      puts "%d tests, %d assertions, %d failures, %d errors" %
+      puts ""
+      puts "", ErrorLog  if Backtraces && ! ErrorLog.empty?
+
+      duration = "%0.2f" % (Time.now - @timer)
+      puts "", "Finished in #{duration} seconds."
+
+      color = GREEN
+      if Counter[:errors] > 0 || Counter[:failed] > 0
+        color = RED
+      end
+
+      puts "#{color}%d tests, %d assertions, %d failures, %d errors#{RESET}" %
         Counter.values_at(:specifications, :requirements, :failed, :errors)
+      puts ""
     end
   end
 


### PR DESCRIPTION
RubyMotion's spec output is a bit dreary -- it works, but it is dense and hard to scan.

This pull colorizes a few aspects of the TestUnit output to more closely resemble that of other Ruby test frameworks: 
- passing specs are denoted by green period
- failing specs are denoted by a red F
- test count line is red or green depending on the passing state of the specs
- the test duration has been truncated to two decimal points
- more whitespace has been added

I'd like to colorize the failing specs as well, but that requires more significant code changes.
