### PR TITLE
Avoid undef'ing _? in spec mode to support coalesce gem

### DIFF
--- a/lib/motion/spec.rb
+++ b/lib/motion/spec.rb
@@ -511,7 +511,8 @@ end
 class Should
   # Kills ==, ===, =~, eql?, equal?, frozen?, instance_of?, is_a?,
   # kind_of?, nil?, respond_to?, tainted?
-  instance_methods.each { |name| undef_method name  if name =~ /\?|^\W+$/ }
+  # Special exception for _? to support the 'coalesce' gem
+  instance_methods.each { |name| undef_method name  if name =~ /(?<!^_)\?|^\W+$/ }
 
   def initialize(object)
     @object = object


### PR DESCRIPTION
This is sort of a special request, but it's a small change, and I haven't found another way to get around this.

And I know the code in question is from bacon; I'm going to pursue this change with them, too, but in plain Ruby I could just use RSpec instead, so I'm not as worried.
