### PR TITLE
Allow get-task-allow to be false

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -664,7 +664,7 @@ EOS
         dict['application-identifier'] ||= seed_id + '.' + identifier
       else
         # Required for gdb.
-        dict['get-task-allow'] ||= true
+        dict['get-task-allow'] = true if dict['get-task-allow'].nil?
       end
       Motion::PropertyList.to_s(dict)
     end


### PR DESCRIPTION
Previously, get-task-allow could not be set to false due to the `||=`-operator, which overrides a setting of `false`. This is very unhandy e.g. for TestFlight.
