### PR TITLE
Adding generator for model and controller

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -176,6 +176,19 @@ task :static do
   sh "/usr/bin/lipo -create #{libs.join(' ')} -output \"#{fat_lib}\""
 end
 
+desc "Creating generator for quickly create files in your application"
+task  :generate  do
+if ENV['scaffold']
+    App.generate_controller(ENV['scaffold'])
+    App.generate_model(ENV['scaffold'])
+elsif ENV['controller']
+  App.generate_controller(ENV['controller'])
+elsif ENV['model']
+  App.generate_model(ENV['model'])
+else
+  puts "command not matched"
+  end
+end
 =begin
 # Automatically load project extensions. A project extension is a gem whose
 # name starts with `motion-' and which exposes a `lib/motion/project' libdir.

--- a/lib/motion/project/app.rb
+++ b/lib/motion/project/app.rb
@@ -145,6 +145,50 @@ EOS
           end
         end
       end
+ def generate_controller(controller_name)
+      fail "Invalid controller name"  unless controller_name.match(/^[\w\s-]+$/)
+      controller_file_path =  'app/'+ controller_name+'_controller.rb'
+      fail "File `#{controller_file_path}' already exists"  if File.exist?(controller_file_path)
+      App.log 'Creating controller', camel_case(controller_name)+"Controller"
+      File.open(controller_file_path, 'w') do |io|
+        io.puts <<EOS
+class #{camel_case(controller_name)}Controller < UIViewController
+  def viewDidLoad
+  # Called when you create the class and load it. Great for initial setup and one-time-only work
+  end
+  def ViewWillAppear
+  #Called right before your view appears, good for hiding/showing fields or any operations that you want to happen every time before the view is visible
+  end
+  def ViewDidAppear
+  #Called after the view appears - great place to start an animations or the loading of external data
+  end
+end
+EOS
+      end
+  App.log 'Created controller', camel_case(controller_name)+"Controller Done!!"
+  end
+
+    def generate_model(model_name)
+        fail "Invalid model name"  unless model_name.match(/^[\w\s-]+$/)
+        model_file_path =  'app/'+ model_name+'.rb'
+        fail "File `#{model_file_path}' already exists"  if File.exist?(model_file_path)
+        App.log 'Creating model', camel_case(model_name)
+        File.open(model_file_path, 'w') do |io|
+          io.puts <<EOS
+class #{camel_case(model_name)}
+
+end
+EOS
+        end
+        App.log 'Created model', camel_case(model_name)+" Done!!"
+      end
+
+
+      def camel_case(some_string)
+        return some_string if some_string !~ /_/ && some_string =~ /[A-Z]+.*/
+        some_string.split('_').map{|e| e.capitalize}.join
+      end
+
 
       def log(what, msg)
         require 'thread'


### PR DESCRIPTION
Added RubyMotion generator to create files, you can easily create controller and model file with rake commands.

To generate both model and controller:

```
   rake generate scaffold=twitter
```

To generate model:

```
   rake generate model=twitter
```

To generate controller:

```
 rake generate controller=twitter
```

Once this pull request is updated I can more work on it and update the docs.
