### PR TITLE
Added formatter for RubyMine tests runner

### DIFF
--- a/lib/motion/spec.rb
+++ b/lib/motion/spec.rb
@@ -22,6 +22,90 @@ module Bacon
 
   Backtraces = true  unless defined? Backtraces
 
+  module RubyMineOutput
+    @@entered = false
+    @@description = nil
+    @@specification = nil
+    @@started = nil
+
+    def handle_specification_begin(name)
+      unless @@entered
+        puts "##teamcity[enteredTheMatrix timestamp = '#{time}']\n\n"
+        @@entered = true
+      end
+      @@specification = name
+      puts "##teamcity[testSuiteStarted timestamp = '#{time}' name = '#{escape_message(name)}']\n\n"
+    end
+
+    def handle_specification_end
+      puts "##teamcity[testSuiteFinished timestamp = '#{time}' name = '#{escape_message(@@specification)}']\n\n" if Counter[:context_depth] == 1
+    end
+
+    def handle_requirement_begin(description)
+      @@description = description
+      @@started = Time.now
+      puts "##teamcity[testStarted timestamp = '#{time}' captureStandardOutput = 'true' name = '#{escape_message(description)}']\n\n"
+    end
+
+    def handle_requirement_end(error)
+      if !error.empty?
+        puts "##teamcity[testFailed timestamp = '#{time}' message = '#{escape_message(error)}' name = '#{escape_message(@@description)}']\n\n"
+      end
+      duration = ((Time.now - @@started) * 1000).to_i
+      puts "##teamcity[testFinished timestamp = '#{time}' duration = '#{duration}' name = '#{escape_message(@@description)}']\n\n"     
+    end
+
+    def handle_summary
+      print ErrorLog if Backtraces
+      puts "%d specifications (%d requirements), %d failures, %d errors" %
+               Counter.values_at(:specifications, :requirements, :failed, :errors)
+    end
+
+    def spaces
+      "  " * (Counter[:context_depth] - 1)
+    end
+
+    def time
+      convert_time_to_java_simple_date(Time.now)
+    end
+
+    def escape_message(message)
+      copy_of_text = String.new(message)
+
+      copy_of_text.gsub!(/\|/, "||")
+
+      copy_of_text.gsub!(/'/, "|'")
+      copy_of_text.gsub!(/\n/, "|n")
+      copy_of_text.gsub!(/\r/, "|r")
+      copy_of_text.gsub!(/\]/, "|]")
+
+      copy_of_text.gsub!(/\[/, "|[")
+
+      begin
+        copy_of_text.encode!('UTF-8') if copy_of_text.respond_to? :encode!
+        copy_of_text.gsub!(/\u0085/, "|x") # next line
+        copy_of_text.gsub!(/\u2028/, "|l") # line separator
+        copy_of_text.gsub!(/\u2029/, "|p") # paragraph separator
+      rescue
+        # it is not an utf-8 compatible string :(
+      end
+
+      copy_of_text
+    end   
+
+    def convert_time_to_java_simple_date(time)
+      gmt_offset = time.gmt_offset
+      gmt_sign = gmt_offset < 0 ? "-" : "+"
+      gmt_hours = gmt_offset.abs / 3600
+      gmt_minutes = gmt_offset.abs % 3600
+
+      millisec = time.usec == 0 ? 0 : time.usec / 1000
+
+      #Time string in Java SimpleDateFormat
+      sprintf("#{time.strftime("%Y-%m-%dT%H:%M:%S.")}%03d#{gmt_sign}%02d%02d", millisec, gmt_hours, gmt_minutes)
+    end
+  end
+
   module SpecDoxOutput
     def handle_specification_begin(name)
       puts spaces + name
@@ -141,7 +225,8 @@ module Bacon
     'fast' => FastOutput,
     'test_unit' => TestUnitOutput,
     'tap' => TapOutput,
-    'knock' => KnockOutput
+    'knock' => KnockOutput,
+    'rubymine' => RubyMineOutput
   }
   extend(Outputs[ENV['output']] || SpecDoxOutput)
 


### PR DESCRIPTION
This formatter provides integration with RubyMine/TeamCity tests runner by using [Service Messages protocol](http://confluence.jetbrains.net/display/TCD65/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ServiceMessages). It allows RubyMine to display nice looking test trees when running tests:
![Tests Runner](http://f.cl.ly/items/1h0L0S221s0C2R2d0E0r/RubyMotion%20Tests%20Runner.png)
