### PR TITLE
Default short_version to be equal to version

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -76,7 +76,7 @@ module Motion; module Project
       @bundle_signature = '????'
       @interface_orientations = [:portrait, :landscape_left, :landscape_right]
       @version = '1.0'
-      @short_version = '1'
+      @short_version = nil
       @status_bar_style = :default
       @background_modes = []
       @icons = []
@@ -588,7 +588,7 @@ EOS
         'CFBundleInfoDictionaryVersion' => '6.0',
         'CFBundlePackageType' => 'APPL',
         'CFBundleResourceSpecification' => 'ResourceRules.plist',
-        'CFBundleShortVersionString' => @short_version,
+        'CFBundleShortVersionString' => (@short_version || @version),
         'CFBundleSignature' => @bundle_signature,
         'CFBundleSupportedPlatforms' => ['iPhoneOS'],
         'CFBundleVersion' => @version,


### PR DESCRIPTION
Reduces friction for the user:
- Most users are not interested in setting a separate `CFBundleShortVersionString`
- The string is required to be unique for every version released to the App Store
- The setting is not generated during `motion create`, and it is not used in any of the examples in [RubyMotionSamples](https://github.com/HipByte/RubyMotionSamples)
