### PR TITLE
Speed up build a little bit.

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -292,15 +292,7 @@ EOS
 
     def ordered_build_files
       @ordered_build_files ||= begin
-        flat_deps = @files.flatten.map { |file| file_dependencies(file) }.flatten
-        paths = flat_deps.dup
-        flat_deps.each do |path|
-          n = paths.count(path)
-          if n > 1
-            (n - 1).times { paths.delete_at(paths.rindex(path)) }
-          end
-        end
-        paths
+        @files.flatten.map { |file| file_dependencies(file) }.flatten.uniq
       end
     end
 


### PR DESCRIPTION
We use rubymotion v1.30 with new automatically detected file dependencies. We have very slow builds (about 30 secs on not cold builds) in project with only 52 ruby files.
After investigating I found that almost all build time rubymotion spend in `Motion::Project::Config#ordered_build_files` (about 24 secs).
`Array#uniq` does exactly what `orderd_build_files` is doing but much much faster.
With this change `Motion::Project::Config#ordered_build_files` takes only about 0.06 secs on my machine.
