### PR TITLE
Allow `rake device` to proceed when using an enterprise provisioning profile

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -138,7 +138,7 @@ desc "Deploy on the device"
 task :device => :archive do
   App.info 'Deploy', App.config.archive
   device_id = (ENV['id'] or App.config.device_id)
-  unless App.config.provisioned_devices.include?(device_id)
+  unless App.config.provisions_all_devices? || App.config.provisioned_devices.include?(device_id)
     App.fail "Device ID `#{device_id}' not provisioned in profile `#{App.config.provisioning_profile}'"
   end
   env = "XCODE_DIR=\"#{App.config.xcode_dir}\""

--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -665,8 +665,26 @@ EOS
     end
     private :read_provisioned_profile_array
 
+    def read_provisioned_profile_boolean(key)
+      text = File.read(provisioning_profile)
+      text.force_encoding('binary') if RUBY_VERSION >= '1.9.0'
+      case text.scan(/<key>\s*#{key}\s*<\/key>\s*<(true|false)\/>/m)[0]
+      when ['true']
+        true
+      when ['false']
+        false
+      else
+        nil
+      end
+    end
+    private :read_provisioned_profile_boolean
+
     def provisioned_devices
       @provisioned_devices ||= read_provisioned_profile_array('ProvisionedDevices')
+    end
+
+    def provisions_all_devices?
+      @provisions_all_devices ||= !!read_provisioned_profile_boolean('ProvisionsAllDevices')
     end
 
     def seed_id


### PR DESCRIPTION
Enterprise provisioning profiles allow any device to install the application; we can check for this by searching for the ProvisionsAllDevices key in the <code>.mobileprovision</code>.

As the script is, <code>rake device</code> will fail saying the device is not in the provisioning profile. I've written a quick patch to allow this function.

It does do two reads on the <code>.mobileprovision</code> now, so perhaps the read should be instanced?