### PR TITLE
create deploy task

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -134,8 +134,11 @@ namespace :spec do
   end
 end
 
+desc "Build archive and deploy on the device"
+task :device => [:archive, :deploy]
+
 desc "Deploy on the device"
-task :device => :archive do
+task :deploy do
   App.info 'Deploy', App.config.archive
   device_id = (ENV['id'] or App.config.device_id)
   unless App.config.provisioned_devices.include?(device_id)


### PR DESCRIPTION
:device task still behaves the same as before, but now there's a separate deploy task so we don't have to rebuild the archive when deploying to multiple devices.
