### PR TITLE
Added extra flag support

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -383,7 +383,7 @@ EOS
         framework_search_paths = config.framework_search_paths.map { |x| "-F#{File.expand_path(x)}" }.join(' ')
         frameworks = config.frameworks_dependencies.map { |x| "-framework #{x}" }.join(' ')
         weak_frameworks = config.weak_frameworks.map { |x| "-weak_framework #{x}" }.join(' ')
-        sh "#{cxx} -o \"#{main_exec}\" #{objs_list} #{config.ldflags(platform)} -L#{File.join(datadir, platform)} -lmacruby-static -lobjc -licucore #{framework_search_paths} #{frameworks} #{weak_frameworks} #{config.libs.join(' ')} #{vendor_libs.map { |x| '-force_load "' + x + '"' }.join(' ')}"
+        sh "#{cxx} -o \"#{main_exec}\" #{objs_list} #{config.ldflags(platform)} -L#{File.join(datadir, platform)} -lmacruby-static -lobjc -licucore #{framework_search_paths} #{frameworks} #{weak_frameworks} #{config.libs.join(' ')} #{vendor_libs.map { |x| '-force_load "' + x + '"' }.join(' ')} #{config.extra_flags}"
         main_exec_created = true
       end
 

--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -52,10 +52,11 @@ module Motion; module Project
       :resources_dir, :specs_dir, :identifier, :codesign_certificate,
       :provisioning_profile, :device_family, :interface_orientations, :version,
       :short_version, :icons, :prerendered_icon, :background_modes, :seed_id,
-      :entitlements, :fonts, :status_bar_style, :motiondir, :detect_dependencies
+      :entitlements, :fonts, :status_bar_style, :motiondir, :detect_dependencies,
+      :extra_flags
 
     # Internal only.
-    attr_accessor :build_mode, :spec_mode, :distribution_mode, :dependencies
+    attr_accessor :build_mode, :spec_mode, :distribution_mode, :dependencies, :extra_flags
 
     def initialize(project_dir, build_mode)
       @project_dir = project_dir
@@ -85,6 +86,7 @@ module Motion; module Project
       @entitlements = {}
       @spec_mode = false
       @build_mode = build_mode
+      @extra_flags = ""
     end
 
     OSX_VERSION = `/usr/bin/sw_vers -productVersion`.strip.sub(/\.\d+$/, '').to_f


### PR DESCRIPTION
I'm not sure if there is a better way to do this but adding this config attribute allowed me to conditionally set compiler flags depending on the target platform (simulator vs device).

eg

```
if @runmode == "device"
  app.extra_flags = "..."
end
```
