### PR TITLE
frameworks folder and framework search path

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -65,7 +65,8 @@ module Motion; module Project
       @detect_dependencies = true
       @frameworks = ['UIKit', 'Foundation', 'CoreGraphics']
       @weak_frameworks = []
-      @framework_search_paths = []
+      frameworks_dir = File.join(project_dir,'frameworks')
+      @framework_search_paths = File.exist?(frameworks_dir) ? [frameworks_dir] : []
       @libs = []
       @delegate_class = 'AppDelegate'
       @name = 'Untitled'


### PR DESCRIPTION
The vendored code works well for code that needs building as part of the process but for pre-built static frameworks, mangling the framework to fit the vendor approach and then loading it in with -force_load didn't work for me.

Just adding a set path to the frameworks search path and referencing the framework as per the system frameworks built correctly.

eg

```
/framworks
  /something.framework

app.frameworks << "something"
```
