### PR TITLE
Include exception message in bacon error output

### DIFF
--- a/lib/motion/spec.rb
+++ b/lib/motion/spec.rb
@@ -413,10 +413,10 @@ module Bacon
 
         @error = if e.kind_of? Error
           Counter[e.count_as] += 1
-          e.count_as.to_s.upcase
+          "#{e.count_as.to_s.upcase} - #{e}"
         else
           Counter[:errors] += 1
-          "ERROR: #{e.class}"
+          "ERROR: #{e.class} - #{e}"
         end
       end
     end


### PR DESCRIPTION
Instead of displaying:

[ERROR: NoMethodError]

This patch causes bacon to display:

[ERROR: NoMethodError - undefined method `foo' for #<MyObject_:0x1234>]
