### PR TITLE
Make _spec suffix optional when running `rake spec files=...`

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -379,7 +379,7 @@ EOS
           # Filter specs we want to run. A filter can be either the basename of a spec file or its path.
           files_filter = files_filter.split(',')
           files_filter.map! { |x| File.exist?(x) ? File.expand_path(x) : x }
-          specs.delete_if { |x| !files_filter.include?(File.expand_path(x)) and !files_filter.include?(File.basename(x, '.rb')) }
+          specs.delete_if { |x| [File.expand_path(x), File.basename(x, '.rb'), File.basename(x, '_spec.rb')].none? { |p| files_filter.include?(p) } }
         end
         core + helpers + specs
       end


### PR DESCRIPTION
With this change, the following invocations are equivalent:

```
rake spec files=integration_spec
```

and

```
rake spec files=integration
```

When a pull request saves 5 keystrokes, can you really say no?

thanks,
Dave
