### PR TITLE
Allow tested controllers to be embedded in standard container controllers

### DIFF
--- a/lib/motion/project/template/ios/spec-helpers/ui.rb
+++ b/lib/motion/project/template/ios/spec-helpers/ui.rb
@@ -224,12 +224,12 @@ module Bacon
         root = controller
 
         # 2. Embed in navigation controller, if specified
-        if embed_in[:navigation]
+        if embed_in.include? :navigation
           root = UINavigationController.alloc.initWithRootViewController(root)
         end
 
         # 3. Embed in tab bar controller, if specified
-        if embed_in[:tab]
+        if embed_in.include? :tab
           root = UITabBarController.new.tap do |tabBarController|
             tabBarController.viewControllers = [root]
           end
@@ -238,7 +238,7 @@ module Bacon
         # 4. TODO Embed in split view controller
 
         # Present modally, if specified
-        if embed_in[:modal]
+        if embed_in.include? :modal
           root = PresentingViewController.alloc.initWithPresenteeViewController(root)
         end
 


### PR DESCRIPTION
Hi @Watson1978

There were TODOs marked in the code for the behaviour described below. I'm not sure if the changes are in pipeline (maybe @alloy might comment), but I needed it for my tests and it has been asked on the mailing list.

I'm not sure how you test changes like this with the toolchain, but if need be, I can provide a sample project that uses this functionality in its tests.

---

When declaring the controller under test, standard iOS container controllers can now be stipulated through keyword options:
1. `:navigation` (`UINavigationController`)
2. `:tab` (`UITabBarController`)
3. `:modal` (`-presentViewController:animated:completion:`)

Example:

``` ruby
    tests HamsterdamController, embed_in: [:navigation, :modal]
```

The use of container controllers is concatenative. For example, if both `:navigation` and `:tab` are specified, the controller under test will be first embedded in a navigation controller, and the navigation controller will be embedded in a tab controller.

In the tests, `#controller` continues refers to the instance of the controller under test even though it is no longer the window's root view controller. To access a container controller, use one of `UIViewController`'s related controller methods, such as `#navigationController`.
