### PR TITLE
Optional automatic Bundler support

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -30,6 +30,8 @@ require 'motion/project/plist'
 
 App = Motion::Project::App
 
+Bundler.require if Object.const_defined?(:Bundler)
+
 # Check for software updates.
 system('/usr/bin/motion update --check')
 if $?.exitstatus == 2
@@ -124,6 +126,7 @@ namespace :spec do
   desc "Run the test/spec suite on the simulator"
   task :simulator do
     App.config.spec_mode = true
+    Bundler.require :default, :spec if Object.const_defined?(:Bundler)
     Rake::Task["simulator"].invoke
   end
 


### PR DESCRIPTION
This commit adds bundler support, including an optional :spec group when running the specs. To use, require bundler from the Rakefile before requiring motion/project. Add all your build and runtime dependencies to your Gemfile, and all testing dependencies to the :spec group.
