### PR TITLE
Rake tasks that make development and testing easier.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,21 @@
+installation_path = "/Library/RubyMotion"
+
+desc "Replace your local installation with this checkout"
+task :install do
+  if File.exist?("#{installation_path}/lib.backup")
+    raise "It seems this local checkout is already installed"
+  else
+    mv "#{installation_path}/lib", "#{installation_path}/lib.backup"
+    ln File.dirname(__FILE__) + "/lib", "#{installation_path}/lib"
+  end
+end
+
+desc "Go back to your original installation"
+task :uninstall do
+  if !File.exist?("#{installation_path}/lib.backup")
+    raise "It seems this local checkout is not installed right now"
+  else
+    rm "#{installation_path}/lib"
+    mv "#{installation_path}/lib.backup", "#{installation_path}/lib"
+  end
+end


### PR DESCRIPTION
To replace your locally installed RubyMotion/lib folder with a checkout of this repository, use the task "rake install". To revert to the official release, use "rake uninstall"
