### PR TITLE
Add Config#exclude_from_detect_dependencies

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -141,7 +141,7 @@ module Motion; module Project;
 
       # Resolve file dependencies
       if config.detect_dependencies == true
-        deps = Dependency.new(config.files).run
+        deps = Dependency.new(config.files - config.exclude_from_detect_dependencies).run
         config.dependencies = deps.merge(config.dependencies)
       end
 

--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -52,7 +52,8 @@ module Motion; module Project
       :resources_dirs, :specs_dir, :identifier, :codesign_certificate,
       :provisioning_profile, :device_family, :interface_orientations, :version,
       :short_version, :icons, :prerendered_icon, :background_modes, :seed_id,
-      :entitlements, :fonts, :status_bar_style, :motiondir, :detect_dependencies
+      :entitlements, :fonts, :status_bar_style, :motiondir, :detect_dependencies,
+      :exclude_from_detect_dependencies
 
     # Internal only.
     attr_accessor :build_mode, :spec_mode, :distribution_mode, :dependencies
@@ -63,6 +64,7 @@ module Motion; module Project
       @info_plist = {}
       @dependencies = {}
       @detect_dependencies = true
+      @exclude_from_detect_dependencies = []
       @frameworks = ['UIKit', 'Foundation', 'CoreGraphics']
       @weak_frameworks = []
       @framework_search_paths = []


### PR DESCRIPTION
Hey guys, basically BubbleWrap has a pretty well-defined but complex dependency graph. Running with `detect_dependencies` produces some wild results and earlier tonight I got some sort of infinite dependency that caused problems (can repro if you want).

So I added `exclude_from_detect_dependencies`, which removes that array of files from being used in the `Dependency` checker. It's is probably a good compromise, pretty sure other large libraries would appreciate this too.

Example:

``` ruby
# in my_gem.rb

Motion::Project::App.setup do |app|
  app.files << MyLib.files
  app.files_dependencies << MyLib.dependency_graph
  app.exclude_from_detect_dependencies << MyLib.files
end
```
