### PR TITLE
Change file dependency regex to accept absolute paths

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -276,7 +276,7 @@ EOS
 
     def files_dependencies(deps_hash)
       res_path = lambda do |x|
-        path = /^\./.match(x) ? x : File.join('.', x)
+        path = /^\.?\//.match(x) ? x : File.join('.', x)
         unless @files.flatten.include?(path)
           App.fail "Can't resolve dependency `#{x}'"
         end


### PR DESCRIPTION
BubbleWrap has had this monkey-patched for ages (currently at [here](https://github.com/rubymotion/BubbleWrap/blob/master/lib/bubble-wrap/ext/motion_project_config.rb), but originally way back in [May 2012](https://github.com/rubymotion/BubbleWrap/commit/02082f896d5375b340876db13cc550dbac933c49#lib/bubble-wrap.rb)).

It allows files to be included with absolute paths (i.e. `/Users/me/.rbenv/gems/BubbleWrap/thing.rb` etc). Currently, if a file is included with an absolute path, the old regex will convert it to a relative path (i.e. `./Users/me/...`), which prevents the file from being found and throws an `App.fail` [here](https://github.com/HipByte/RubyMotion/blob/master/lib/motion/project/config.rb#L281).

Would love to see this accepted into the main repo, or an explanation for why it isn't desired :)
