### PR TITLE
Set `spec_mode` before `setup`

### DIFF
--- a/lib/motion/project/template/ios.rb
+++ b/lib/motion/project/template/ios.rb
@@ -102,7 +102,7 @@ namespace :archive do
   desc "Create an .ipa archive for distribution (AppStore)"
   task :distribution do
     App.config_without_setup.build_mode = :release
-    App.config.distribution_mode = true
+    App.config_without_setup.distribution_mode = true
     Rake::Task["archive"].invoke
   end
 end
@@ -113,13 +113,13 @@ task :spec => ['spec:simulator']
 namespace :spec do
   desc "Run the test/spec suite on the simulator"
   task :simulator do
-    App.config.spec_mode = true
+    App.config_without_setup.spec_mode = true
     Rake::Task["simulator"].invoke
   end
 
   desc "Run the test/spec suite on the device"
   task :device do
-    App.config.spec_mode = true
+    App.config_without_setup.spec_mode = true
     ENV['debug'] ||= '1'
     Rake::Task["device"].invoke
   end

--- a/lib/motion/project/template/osx.rb
+++ b/lib/motion/project/template/osx.rb
@@ -61,7 +61,7 @@ end
 
 desc "Run the test/spec suite"
 task :spec do
-  App.config.spec_mode = true
+  App.config_without_setup.spec_mode = true
   Rake::Task["run"].invoke
 end
 
@@ -74,7 +74,7 @@ end
 namespace :archive do
   desc "Create a .pkg archive for distribution (AppStore)"
   task :distribution do
-    App.config.distribution_mode = true
+    App.config_without_setup.distribution_mode = true
     Rake::Task['archive'].invoke
   end
 end


### PR DESCRIPTION
tl;dr it makes this possible

``` ruby
Motion::Project::App.setup do |app|
  if app.spec_mode
    app.delegate_class = "SpecAppDelegate"
  end
end
```

I wanted to be able to do spec-mode-dependent actions in my `App.setup` block, but couldn't because the blocks were all run immediately _before_ `app.spec_mode` was set in `project.rb`. This was because plain `App.config` triggers `setup` immediately.

This changes `App.config` to `App.config_without_setup`, so the `App.setup` blocks are run _after_ `spec_mode` has been set.
