### PR TITLE
Update motion require statement in gem template Rakefile

### DIFF
--- a/lib/motion/project/template/gem/files/Rakefile.erb
+++ b/lib/motion/project/template/gem/files/Rakefile.erb
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project'
+require 'motion/project/template/ios'
 require './lib/<%= name %>'
 
 Motion::Project::App.setup do |app|


### PR DESCRIPTION
Current require statement is causing the following depreciated warning in RubyMotion 2.0 after creating an app from the 'gem' template:

``` bash
require 'lib/motion/project' is deprecated, please require 'lib/motion/project/template/ios' instead
```
