### PR TITLE
Files dependencies fixes

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -205,7 +205,7 @@ module Motion; module Project
 
     def files_dependencies(deps_hash)
       res_path = lambda do |x|
-        path = /^\.?\//.match(x) ? x : File.join('.', x)
+        path = /^\.{0,2}\//.match(x) ? x : File.join('.', x)
         unless @files.flatten.include?(path)
           App.fail "Can't resolve dependency `#{path}'"
         end


### PR DESCRIPTION
I'm working on a different dependency loading mechanism for a current project and I came across two quirks in the `Motion::Project::Config#files_dependencies` method.

The first is that, if a pathname had "./" prepended to it, but then could not be found in the files list, the pathname without "./" was given in the exception instead of the updated filename. More helpful for debugging than anything.

The second issue was that the regex for determining if a pathname is relative did not support the "../" directory ascending notation.

It also looks like there's a bit of trailing whitespace cleanup in the patch.

Thanks for the awesome work!
