### PR TITLE
Set NSZombieEnabled=YES in simulator by passing zombie=1 to rake

### DIFF
--- a/lib/motion/project/template/ios.rb
+++ b/lib/motion/project/template/ios.rb
@@ -86,6 +86,7 @@ task :simulator => ['build:simulator'] do
   xcode = App.config.xcode_dir
   env = "DYLD_FRAMEWORK_PATH=\"#{xcode}/../Frameworks\":\"#{xcode}/../OtherFrameworks\""
   env << ' SIM_SPEC_MODE=1' if App.config.spec_mode
+  env << ' NSZombieEnabled=YES' if ENV['zombie']
   sim = File.join(App.config.bindir, 'ios/sim')
   debug = (ENV['debug'] ? 1 : (App.config.spec_mode ? '0' : '2'))
   App.info 'Simulate', app


### PR DESCRIPTION
Title says it all.  It might be more useful to have a generic way to pass arbitrary environment variables that will be set when running the simulator (without affecting the rest of the build tools).
