### PR TITLE
Allow uppercase 'debug' environment variable

### DIFF
--- a/lib/motion/project/template/ios.rb
+++ b/lib/motion/project/template/ios.rb
@@ -87,7 +87,7 @@ task :simulator => ['build:simulator'] do
   env = "DYLD_FRAMEWORK_PATH=\"#{xcode}/../Frameworks\":\"#{xcode}/../OtherFrameworks\""
   env << ' SIM_SPEC_MODE=1' if App.config.spec_mode
   sim = File.join(App.config.bindir, 'ios/sim')
-  debug = (ENV['debug'] ? 1 : (App.config.spec_mode ? '0' : '2'))
+  debug = ((ENV['debug'] || ENV['DEBUG']) ? 1 : (App.config.spec_mode ? '0' : '2'))
   App.info 'Simulate', app
   at_exit { system("stty echo") } if $stdout.tty? # Just in case the simulator launcher crashes and leaves the terminal without echo.
   sh "#{env} #{sim} #{debug} #{family_int} #{target} \"#{xcode}\" \"#{app}\""

--- a/lib/motion/project/template/osx.rb
+++ b/lib/motion/project/template/osx.rb
@@ -52,7 +52,7 @@ task :run => 'build:development' do
   env = ''
   env << 'SIM_SPEC_MODE=1' if App.config.spec_mode
   sim = File.join(App.config.bindir, 'osx/sim')
-  debug = (ENV['debug'] ? 1 : (App.config.spec_mode ? '0' : '2'))
+  debug = ((ENV['debug'] || ENV['DEBUG']) ? 1 : (App.config.spec_mode ? '0' : '2'))
   target = App.config.sdk_version
   App.info 'Run', exec
   at_exit { system("stty echo") } if $stdout.tty? # Just in case the process crashes and leaves the terminal without echo.


### PR DESCRIPTION
I ran into this when I couldn't understand why the debugger wasn't starting. My impression is that upper case environment variables are more common than lowe rcase, but I'm not sure what the 'best practice' is.
