### PR TITLE
Use absolute path for CONFIGURATION_BUILD_DIR

### DIFF
--- a/lib/motion/project/vendor.rb
+++ b/lib/motion/project/vendor.rb
@@ -170,12 +170,13 @@ EOS
           # Build project into a build directory. We delete the build directory
           # each time because Xcode is too stupid to be trusted to use the
           # same build directory for different platform builds.
-          rm_rf XcodeBuildDir
+          xcode_build_dir = File.expand_path(XcodeBuildDir)
+          rm_rf xcode_build_dir
           xcopts = ''
           xcopts << "-target \"#{target}\" " if target
           xcopts << "-scheme \"#{scheme}\" " if scheme
-          sh "/usr/bin/xcodebuild -project \"#{xcodeproj}\" #{xcopts} -configuration \"#{configuration}\" -sdk #{platform.downcase}#{@config.sdk_version} #{@config.arch_flags(platform)} CONFIGURATION_BUILD_DIR=#{XcodeBuildDir} IPHONEOS_DEPLOYMENT_TARGET=#{@config.deployment_target} build"
-  
+          sh "/usr/bin/xcodebuild -project \"#{xcodeproj}\" #{xcopts} -configuration \"#{configuration}\" -sdk #{platform.downcase}#{@config.sdk_version} #{@config.arch_flags(platform)} CONFIGURATION_BUILD_DIR=#{xcode_build_dir} IPHONEOS_DEPLOYMENT_TARGET=#{@config.deployment_target} build"
+
           # Copy .a files into the platform build directory.
           prods = opts.delete(:products)
           Dir.glob(File.join(XcodeBuildDir, '*.a')).each do |lib|


### PR DESCRIPTION
When using a non-standard vendored Xcode project, the static libraries gets built into the wrong `.build` folder, which then causes the static library check to fail as it looks in the wrong location.

This PR passes an absolute path to `CONFIGURATION_BUILD_DIR` which fixes this issue.
