### PR TITLE
Add :force_rebuild option for vendored xcodeproj

### DIFF
--- a/lib/motion/project/vendor.rb
+++ b/lib/motion/project/vendor.rb
@@ -145,8 +145,8 @@ EOS
     def build_xcode(platform, opts)
       Dir.chdir(@path) do
         build_dir = "build-#{platform}"
-        if !File.exist?(build_dir)
-          FileUtils.mkdir build_dir
+        if !File.exist?(build_dir) || opts.delete(:force_rebuild)
+          FileUtils.mkdir_p build_dir
 
           # Prepare Xcode project settings.
           xcodeproj = opts.delete(:xcodeproj) || begin


### PR DESCRIPTION
This PR adds a `:force_rebuild` option to vendored Xcode projects, which will attempt to rebuild the Xcode project every time.

My use case is that I'm using RubyMotion to test my existing Objective-C project, so the vendored project will change quite often. If no code has changed, only the `libtool` step runs so it's quite fast.
