### PR TITLE
add callback after created controller.

### DIFF
--- a/lib/motion/project/template/ios/spec-helpers/ui.rb
+++ b/lib/motion/project/template/ios/spec-helpers/ui.rb
@@ -213,10 +213,15 @@ module Bacon
       attr_accessor :controller
 
       def controller
-        @controller ||= if @options[:id]
-          storyboard.instantiateViewControllerWithIdentifier(@options[:id])
-        else
-          @controller_class.alloc.init
+        @controller ||= begin
+          c = nil
+          if @options[:id]
+            c = storyboard.instantiateViewControllerWithIdentifier(@options[:id])
+          else
+            c = @controller_class.alloc.init
+          end
+          send(@options[:after_created], c) if @options[:after_created]
+          c
         end
       end
 


### PR DESCRIPTION
Sometimes view controller has data.
The controller was set as a root view controller to the window before called "before" block.
But a data is not set at this point.
The view controller access to nil, and crash sometime even if I set data in "before" block.

After created controller it will call the specified callback method if you set :after_created option
# Example

``` ruby
# my_view_controller_spec.rb
describe MyViewController do

  tests MyViewController, after_created: :after_created_controller

  def after_created_controller controller
    # you can set data to the controller here
    controller.my_data = "foo"
  end

  .
  .
end
```
