### PR TITLE
Fix build expression for Xcode 3.x

### DIFF
--- a/lib/motion/project/xcode_config.rb
+++ b/lib/motion/project/xcode_config.rb
@@ -82,7 +82,7 @@ EOS
       @xcode_version ||= begin
         txt = `#{locate_binary('xcodebuild')} -version`
         vers = txt.scan(/Xcode\s(.+)/)[0][0]
-        build = txt.scan(/Build version\s(.+)/)[0][0]
+        build = txt.scan(/(BuildVersion:|Build version)\s(.+)/)[0][1]
         [vers, build]
       end
     end


### PR DESCRIPTION
With Xcode version 3.2 on my machine I was unable to run rake on a newly created project.

The exact failure was:

```
rake aborted!
undefined method `[]' for nil:NilClass
/Library/RubyMotion/lib/motion/project/xcode_config.rb:85:in `xcode_version'
/Library/RubyMotion/lib/motion/project/xcode_config.rb:96:in `validate'
/Library/RubyMotion/lib/motion/project/template/ios/config.rb:61:in `validate'
/Library/RubyMotion/lib/motion/project/config.rb:108:in `setup'
/Library/RubyMotion/lib/motion/project/app.rb:64:in `config'
/Library/RubyMotion/lib/motion/project/app.rb:76:in `build'
/Library/RubyMotion/lib/motion/project/template/ios.rb:42:in `block (2 levels) in <top (required)>'
```

Not having a very friendly error message made this problem much more difficult to resolve. The provided fix allows RubyMotion to retrieve the version number properly. It can then recognize the version as being out of data and print a nice error message.
