### PR TITLE
Adds a check in the `rake clean` process for nib/xib existence.

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -1,15 +1,15 @@
 # Copyright (c) 2012, HipByte SPRL and contributors
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
 #    list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,8 +44,15 @@ task :clean do
   rm_rf(App.config.build_dir)
   App.config.vendor_projects.each { |vendor| vendor.clean }
   Dir.glob(App.config.resources_dirs.flatten.map{ |x| x + '/**/*.{nib,storyboardc,momd}' }).each do |p|
-    App.info 'Delete', p
-    rm_rf p
+    if p.include?('nib')
+      if File.exist?(p.gsub('nib', 'xib'))
+        App.info 'Delete', p
+        rm_rf p
+      end
+    else
+      App.info 'Delete', p
+      rm_rf p
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #78 by checking for the existence of a xib when attempting to clean a nib file. If a xib file exists, delete the nib; otherwise, delete it.

Apologies for the weirdness in the diff up top, not sure what the deal with that is. 
