### PR TITLE
Run after filters before verifying there are expectations

### DIFF
--- a/lib/motion/spec.rb
+++ b/lib/motion/spec.rb
@@ -414,11 +414,11 @@ module Bacon
     end
 
     def finish_spec
+      run_after_filters
       if !@exception_occurred && Counter[:requirements] == @number_of_requirements_before
         # the specification did not contain any requirements, so it flunked
         execute_block { raise Error.new(:missing, "empty specification: #{@context.name} #{@description}") }
       end
-      run_after_filters
       exit_spec unless postponed?
     end
 


### PR DESCRIPTION
Currently, spec gems such as WebStub and motion-stump have difficulty expressing mock expectations, because these sorts of mocks usually would end up in an `after` block registered by the library. However, Bacon expects `after` blocks to be used for clean-up only. Because `after` blocks are not allowed to contain expectations, users have to clutter their code with bogus expectations like `1.should == 1` in order to get the tests to pass.

This pull request simply runs the after filters before verifying at least one expectation is set, allowing `after` blocks to contain expectations.
