### PR TITLE
Adds global `spec_mode?` method

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -69,3 +69,7 @@ task :ctags do
     sh "#{ctags} --options=\"#{config}\" #{bs_files.map { |x| '"' + x + '"' }.join(' ')}"
   end
 end
+
+def spec_mode?
+  Rake.application.top_level_tasks.include? 'spec'
+end


### PR DESCRIPTION
To make it easy to add spec-only bundles.

``` ruby
if spec_mode?
  Bundler.require :spec
end

Motion::Project::App.setup do |app|
  # ...
```
