### PR TITLE
Add Gemfile to templates in `motion create`

### DIFF
--- a/lib/motion/project/template/gem/files/Gemfile
+++ b/lib/motion/project/template/gem/files/Gemfile
@@ -1,3 +1,1 @@
 source 'https://rubygems.org'
-
-gem 'rake'

--- a/lib/motion/project/template/ios/files/Gemfile
+++ b/lib/motion/project/template/ios/files/Gemfile
@@ -1,3 +1,1 @@
 source 'https://rubygems.org'
-
-gem 'rake'

--- a/lib/motion/project/template/osx/files/Gemfile
+++ b/lib/motion/project/template/osx/files/Gemfile
@@ -1,3 +1,1 @@
 source 'https://rubygems.org'
-
-gem 'rake'


### PR DESCRIPTION
Add a default `Gemfile` to each template -- `gem`, `ios`, `osx`. 

The second step in most RubyMotion projects is to create a Gemfile -- without it, `rake` doesn't work. This is a relatively small change that should complete the templates so that they can run immediately upon creation. 
