### PR TITLE
String deployment_target and sdk_version comparison fix

### DIFF
--- a/lib/motion/project/xcode_config.rb
+++ b/lib/motion/project/xcode_config.rb
@@ -104,7 +104,7 @@ EOS
       end
 
       # deployment_target
-      if deployment_target > sdk_version
+      if deployment_target.to_f > sdk_version.to_f
         App.fail "Deployment target `#{deployment_target}' must be equal or lesser than SDK version `#{sdk_version}'"
       end
       unless File.exist?(datadir)


### PR DESCRIPTION
Rakefile:

``` ruby
$:.unshift("/Library/RubyMotion/lib")
require 'motion/project/template/osx'

Motion::Project::App.setup do |app|
  app.deployment_target = '4.3'
  app.sdk_version = '10.8'
end
```

In Ruby string '4.3' not lesser then string '10.8'. It would be more correct if we convert them to float before comparison.

Also I found that IPHONEOS_DEPLOYMENT_TARGET gets common (for IOS and OSX) deployment target from config:
https://github.com/Tensho/RubyMotion/blob/master/lib/motion/project/vendor.rb#L178
Maybe it would be more correct to separate them for deployment_target_ios and deployment_target_osx or to define app template in configuration to avoid mess. OSX SDK version should not influence for IPHONEOS_DEPLOYMENT_TARGET, I think.
