### PR TITLE
Fix shell escaping for file names

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -73,5 +73,5 @@ end
 desc "Open the latest crash report generated for the app"
 task :crashlog do
   logs = Dir.glob(File.join(File.expand_path("~/Library/Logs/DiagnosticReports/"), "#{App.config.name}_*"))
-  sh "open -a Console #{logs.last}"
+  sh "open -a Console #{Shellwords.escape(logs.last)}"
 end


### PR DESCRIPTION
If `App.config.name` has spaces in the name, then `rake crashlog` doesn't work. This fixes that by properly escaping the string for the shell.
