### PR TITLE
Support app_store_category config var for OSX apps.

### DIFF
--- a/lib/motion/project/template/osx/config.rb
+++ b/lib/motion/project/template/osx/config.rb
@@ -112,7 +112,7 @@ module Motion; module Project;
         'NSPrincipalClass' => 'NSApplication',
         'CFBundleIconFile' => (icon or ''),
         'LSMinimumSystemVersion' => deployment_target,
-        'LSMinimumSystemVersion' => (@category.start_with?('public.app-category') ? @category : 'public.app-category.' + @category)
+        'LSApplicationCategoryType' => (@category.start_with?('public.app-category') ? @category : 'public.app-category.' + @category)
       }.merge(generic_info_plist).merge(dt_info_plist).merge(info_plist))
     end
 


### PR DESCRIPTION
Allows you to set app_store category configuration value instead of doing this:

``` ruby
app.info_plist['LSApplicationCategoryType'] = 'public.app-category.developer-tools'
```

This allows you to specify:

`app.app_store_category = 'public.app-category.developer-tools'`
 ~ or ~
`app.app_store_category = 'developer-tools'`

This value is required to submit apps to the Mac App Store.
