### PR TITLE
Add ability to pass in :products option to vendored Xcode projects

### DIFF
--- a/lib/motion/project/vendor.rb
+++ b/lib/motion/project/vendor.rb
@@ -202,7 +202,8 @@ EOS
         end
 
         @bs_files = Dir.glob('*.bridgesupport').map { |x| File.expand_path(x) }
-        @libs = Dir.glob("#{build_dir}/*.a").map { |x| File.expand_path(x) }
+        products = opts[:products] && opts[:products].map { |product| "#{build_dir}/#{product}" }
+        @libs = (products || Dir.glob("#{build_dir}/*.a")).map { |x| File.expand_path(x) }
       end
     end
 


### PR DESCRIPTION
This PR adds the ability to specify a `:products` option to the Xcode vendor project type to match the `:products` option on static vendor projects.

Use case:
Cocoapods recently added dedicated targets for each pod (https://github.com/CocoaPods/CocoaPods/pull/983) , then link it all together in `libPods.a`. However, RubyMotion attempts to `-force_load` in all the libraries found in the Pods build directory which includes all the `libPods-RegexKitLite.a` etc, so it ends up failing to link due to duplicate symbols.

I use the following with the patch below to fix the issue:

``` ruby
  app.vendor_project('Pods', :xcode,
                      :target        => 'Pods',
                      :products => ['libPods.a'])
```
