### PR TITLE
Fixed issue where template working trees would not be updated upon git pull

### DIFF
--- a/lib/motion/project/template.rb
+++ b/lib/motion/project/template.rb
@@ -1,15 +1,15 @@
 # Copyright (c) 2012, HipByte SPRL and contributors
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # 1. Redistributions of source code must retain the above copyright notice, this
 #    list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 #    this list of conditions and the following disclaimer in the documentation
 #    and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -152,7 +152,7 @@ module Motion; module Project
         if File.exist?(path)
           # directory exists just do a pull
           App.log 'Template', "#{@name} already exists, performing a pull"
-          system("GIT_DIR=#{path}/.git git pull origin master")
+          system("git --work-tree=#{path} --git-dir=#{path}/.git pull origin master")
         else
           # no directory exists so clone
           result = system("git clone #{@url} #{path}")


### PR DESCRIPTION
When using a previously-cloned template, the template repository is updated (via git pull) but the working tree doesn't get updated. This pull request fixes that.

More background: https://github.com/clearsightstudio/ProMotion/pull/288#issuecomment-23800502
