### PR TITLE
Fix: platform names generated in Info.plist (DTSDKName and DTPlatformName)

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -307,7 +307,7 @@ EOS
       bundle_info_plist = File.join(bundle_path, 'Info.plist')
       if !File.exist?(bundle_info_plist) or File.mtime(config.project_file) > File.mtime(bundle_info_plist)
         App.info 'Create', bundle_info_plist
-        File.open(bundle_info_plist, 'w') { |io| io.write(config.info_plist_data) }
+        File.open(bundle_info_plist, 'w') { |io| io.write(config.info_plist_data(platform)) }
         sh "/usr/bin/plutil -convert binary1 \"#{bundle_info_plist}\""
       end
 

--- a/lib/motion/project/template/ios/config.rb
+++ b/lib/motion/project/template/ios/config.rb
@@ -295,7 +295,7 @@ module Motion; module Project;
       end
     end
 
-    def info_plist_data
+    def info_plist_data(platform)
       ios_version_to_build = lambda do |vers|
         # XXX we should retrieve these values programmatically.
         case vers
@@ -330,9 +330,9 @@ module Motion; module Project;
           end
         end,
         'DTXcodeBuild' => xcode_version[1],
-        'DTSDKName' => "iphoneos#{sdk_version}",
+        'DTSDKName' => "#{platform.downcase}#{sdk_version}",
         'DTSDKBuild' => ios_version_to_build.call(sdk_version),
-        'DTPlatformName' => 'iphoneos',
+        'DTPlatformName' => platform.downcase,
         'DTCompiler' => 'com.apple.compilers.llvm.clang.1_0',
         'DTPlatformVersion' => sdk_version,
         'DTPlatformBuild' => ios_version_to_build.call(sdk_version)

--- a/lib/motion/project/template/osx/config.rb
+++ b/lib/motion/project/template/osx/config.rb
@@ -108,7 +108,7 @@ module Motion; module Project;
       File.join(app_bundle(platform), 'Resources')
     end
 
-    def info_plist_data
+    def info_plist_data(platform)
       Motion::PropertyList.to_s({
         'NSHumanReadableCopyright' => copyright,
         'NSPrincipalClass' => 'NSApplication',


### PR DESCRIPTION
Currently, Info.plist generated always has these values:

DTSDKName = iphoneos7.0
DTPlatformName = iphoneos

but for simulator builds, we really should have:

DTSDKName = iphonesimulator7.0
DTPlatformName = iphonesimulator

This, at least affects https://app.io, which requires simulator builds to be uploaded and checks for the value of DTSDKName.
