### PR TITLE
clean common_build_dir with everything else.

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -42,6 +42,10 @@ desc "Clear build objects"
 task :clean do
   App.info 'Delete', App.config.build_dir
   rm_rf(App.config.build_dir)
+  
+  App.info 'Delete', Motion::Project::Builder.common_build_dir
+  rm_rf Motion::Project::Builder.common_build_dir
+  
   App.config.vendor_projects.each { |vendor| vendor.clean }
   Dir.glob(App.config.resources_dirs.flatten.map{ |x| x + '/**/*.{nib,storyboardc,momd}' }).each do |p|
     next if File.extname(p) == ".nib" && !File.exist?(p.sub(/\.nib$/, ".xib"))


### PR DESCRIPTION
Fixes issues when gem depends on a CocoaPod. Specifically iCarousel and Geomotion. If there is a better way to clean the common_build_dir I'm open to it.
