### PR TITLE
added rakefile check for ENV['ARRAY_CYCLES_DISABLE'] (this can now live ...

### DIFF
--- a/lib/motion/project/template/ios/config.rb
+++ b/lib/motion/project/template/ios/config.rb
@@ -29,7 +29,7 @@ module Motion; module Project;
 
     variable :device_family, :interface_orientations, :background_modes,
       :status_bar_style, :icons, :prerendered_icon, :fonts, :seed_id,
-      :provisioning_profile, :manifest_assets
+      :provisioning_profile, :manifest_assets, :environment_variables
 
     def initialize(project_dir, build_mode)
       super
@@ -41,6 +41,7 @@ module Motion; module Project;
       @icons = []
       @prerendered_icon = false
       @manifest_assets = []
+      @environment_variables = {}
     end
 
     def platforms; ['iPhoneSimulator', 'iPhoneOS']; end
@@ -454,7 +455,7 @@ main(int argc, char **argv)
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     int retval = 0;
 EOS
-    if ENV['ARR_CYCLES_DISABLE']
+    if(ENV['ARR_CYCLES_DISABLE'] || environment_variables['ARR_CYCLES_DISABLE'])
       main_txt << <<EOS
     setenv("ARR_CYCLES_DISABLE", "1", true);
 EOS

--- a/lib/motion/project/template/osx/config.rb
+++ b/lib/motion/project/template/osx/config.rb
@@ -30,7 +30,7 @@ module Motion; module Project;
     register :osx
 
     variable :icon, :copyright, :category, :embedded_frameworks,
-        :codesign_for_development
+        :codesign_for_development, :environment_variables
 
     def initialize(project_dir, build_mode)
       super
@@ -40,6 +40,7 @@ module Motion; module Project;
       @frameworks = ['AppKit', 'Foundation', 'CoreGraphics']
       @embedded_frameworks = []
       @codesign_for_development = false
+      @environment_variables = {}
     end
 
     def platforms; ['MacOSX']; end
@@ -191,7 +192,7 @@ main(int argc, char **argv)
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 EOS
-    if ENV['ARR_CYCLES_DISABLE']
+    if(ENV['ARR_CYCLES_DISABLE'] || environment_variables['ARR_CYCLES_DISABLE'])
       main_txt << <<EOS
     setenv("ARR_CYCLES_DISABLE", "1", true);
 EOS


### PR DESCRIPTION
...in source)

Hey guys,

I have two live games using RM now -- one using the cycle detector with no problems and one that hangs without ARR_CYCLES_DISABLE=1 specified at rake time. As I'm doing updates for the two projects, it's starting to be a headache to remember which one I use it on and which one I disable it on. I poked through the source and it seems pretty trivial to just add it as a config variable in the Rakefile for the project.

Now it can live in source and give me piece of mind! 

I only implemented my actual use case, but it would be trivial to change it so that it actually replaces the setenv call with the value specified by the @environment_variables hash... let me know!
