### PR TITLE
Allow to open the simulator with a non-retina iPad in iOS7

### DIFF
--- a/lib/motion/project/template/ios/config.rb
+++ b/lib/motion/project/template/ios/config.rb
@@ -223,6 +223,7 @@ module Motion; module Project;
           ''
         else
           (family == 1) ? ' Retina (4-inch)' : ' Retina'
+          (family == 1) ? ' Retina (4-inch)' : ''
         end
       end
     end


### PR DESCRIPTION
With the current implementation the following command always opens a retina iPad simulation:

``` bash
rake device_family=ipad 
```

With this change it switches back to:

``` bash
rake device_family=ipad  # non-retina ✝
rake device_family=ipad retina=true # retina
```

✝ _Apparently the Simulator opens with the last used setting when no string is given. Switching to non-retina and running the rake command works_
