### PR TITLE
Add `context` method as `describe` alias

### DIFF
--- a/lib/motion/spec.rb
+++ b/lib/motion/spec.rb
@@ -586,6 +586,8 @@ module Bacon
     def raise?(*args, &block); block.raise?(*args); end
     def throw?(*args, &block); block.throw?(*args); end
     def change?(*args, &block); block.change?(*args); end
+
+    alias_method :context, :describe
   end
 end
 
@@ -643,6 +645,8 @@ module Kernel
   private
   def describe(*args, &block) Bacon::Context.new(args.join(' '), &block)  end
   def shared(name, &block)    Bacon::Shared[name] = block                 end
+
+  alias_method :context, :describe
 end
 
 class Should


### PR DESCRIPTION
This PR adds `context` method as alias of `describe` that is like RSpec style.

[I already added PR like this one to `alloy/MacBacon`](https://github.com/alloy/MacBacon/pull/2) and it was merged to master branch.
If spec.rb in RubyMotion will be updated by MacBacon's master branch code, you can ignore this request.
(I don't know a relation between spec.rb in RubyMotion and MacBacon, sorry. :sweat: )
