### PR TITLE
hack to work with cocoapods's bundle_resources

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -454,6 +454,10 @@ EOS
         copy_resource(res_path, File.join(app_resources_dir, res))
       end
 
+      Dir.glob('vendor/Pods/.build/*.bundle').each do |path|
+        copy_resource(path, File.join(app_resources_dir, File.basename(path)))
+      end
+
       # Optional support for #eval (OSX-only).
       if config.respond_to?(:eval_support) and config.eval_support
         repl_dylib_path = File.join(datadir, '..', 'libmacruby-repl.dylib')


### PR DESCRIPTION
Pods using bundle_resources, for instance ShareKit 2.4.6, generate bundles under vendor/Pods/.build.
This hack grabs bundles made by bundle_resources.
It should be done by motion-cocoapods, but I could not find a good way.
Is there any good alternatives?
