### PR TITLE
modify gem spec files to the `git ls-files` generated list

### DIFF
--- a/lib/motion/project/template/gem/files/{name}.gemspec.erb
+++ b/lib/motion/project/template/gem/files/{name}.gemspec.erb
@@ -11,10 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = ""
 
-  files = []
-  files << 'README.md'
-  files.concat(Dir.glob('lib/**/*.rb'))
-  spec.files         = files
+  spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Hi.
I think better that the files specified in gemspec generated by `git ls-files` for many people.
