### PR TITLE
support dynamic name directory in template

### DIFF
--- a/lib/motion/project/template.rb
+++ b/lib/motion/project/template.rb
@@ -119,7 +119,7 @@ module Motion; module Project
     end
 
     def replace_file_name(file_name)
-      file_name = file_name.sub("{name}", "#{@name}")
+      file_name = file_name.gsub("{name}", "#{@name}")
       file_name
     end
 


### PR DESCRIPTION
support dynamic name directory in template

before

```
motion create foo --template=my_template
  Create foo
  Create foo/app/app_delegate.rb
  Create foo/Gemfile
  Create foo/lib/foo/bar.rb # lib/{name}/bar.rb
/Library/RubyMotion/lib/motion/project/template.rb:110:in `initialize': No such file or directory - lib/foo/bar.rb (Errno::ENOENT)
```

after

```
motion create foo --template=my_template
  Create foo
  Create foo/app/app_delegate.rb
  Create foo/Gemfile
  Create foo/lib/foo/bar.rb # lib/{name}/bar.rb
  Create ...
```
