### PR TITLE
ignore spurious UIApplicationDidBecomeActiveNotification events

### DIFF
--- a/lib/motion/project/template/ios/config.rb
+++ b/lib/motion/project/template/ios/config.rb
@@ -419,9 +419,6 @@ EOS
       if spec_mode
         main_txt << <<EOS
 @interface SpecLauncher : NSObject
-{
-  BOOL hasLaunched;
-}
 @end
 
 #include <dlfcn.h>
@@ -457,22 +454,12 @@ EOS
     return launcher;
 }
 
-- (id)init
-{
-    self = [super init];
-    if (self) {
-        hasLaunched = NO;
-    }
-    return self;
-}
-
 - (void)appLaunched:(id)notification
 {
-    if (!hasLaunched) {
-        // Give a bit of time for the simulator to attach...
-        [self performSelector:@selector(runSpecs) withObject:nil afterDelay:0.3];
-        hasLaunched = YES;
-    }
+    // Give a bit of time for the simulator to attach...
+    [self performSelector:@selector(runSpecs) withObject:nil afterDelay:0.3];
+    // unregister observer to avoid duplicate invocation
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 }
 
 - (void)runSpecs


### PR DESCRIPTION
If a RM app receives extra `UIApplicationDidBecomeActiveNotification` events while a test suite is in progress, the test harness will attempt to re-load the Bacon module definition (`lib/motion/spec.rb`).

Extra `UIApplicationDidBecomeActiveNotification` notifications will happen if the simulator throws up a permissions dialog (e.g. for access to the Address Book or some other iOS service).

This patch ignores any of these notifications after the first.  Bacon will only be initiated the first time.
