### PR TITLE
Ignore .dat* files on new projects.

### DIFF
--- a/lib/motion/project/template/gem/files/.gitignore
+++ b/lib/motion/project/template/gem/files/.gitignore
@@ -15,3 +15,4 @@ nbproject
 .eprj
 .sass-cache
 .idea
+.dat*.*

--- a/lib/motion/project/template/ios/files/.gitignore
+++ b/lib/motion/project/template/ios/files/.gitignore
@@ -14,3 +14,4 @@ nbproject
 .eprj
 .sass-cache
 .idea
+.dat*.*

--- a/lib/motion/project/template/osx/files/.gitignore
+++ b/lib/motion/project/template/osx/files/.gitignore
@@ -14,3 +14,4 @@ nbproject
 .eprj
 .sass-cache
 .idea
+.dat*.*


### PR DESCRIPTION
These are just repl history and probably shouldn't be committed into source control.
