### PR TITLE
Add gemspec call to Gemfile for gem template.

### DIFF
--- a/lib/motion/project/template/gem/files/Gemfile
+++ b/lib/motion/project/template/gem/files/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-# Add your dependencies here:
+# Define all dependencies in your .gemspec file
+gemspec


### PR DESCRIPTION
Since `spec.add_development_dependency "rake"` is already in the `gemspec` template, we don't need it in the `Gemfile` and we should always defer to the `gemspec` for our dependencies except for advanced use cases.
