### PR TITLE
Include application's source code when running `rake ctags`

### DIFF
--- a/lib/motion/project.rb
+++ b/lib/motion/project.rb
@@ -82,7 +82,7 @@ task :ctags do
   tags_file = 'tags'
   config = App.config
   if !File.exist?(tags_file) or File.mtime(config.project_file) > File.mtime(tags_file)
-    bs_files = config.bridgesupport_files + config.vendor_projects.map { |p| Dir.glob(File.join(p.path, '*.bridgesupport')) }.flatten
+    bs_files = config.bridgesupport_files + config.vendor_projects.map { |p| Dir.glob(File.join(p.path, '*.bridgesupport')) }.flatten + config.files.flatten
     ctags = File.join(config.bindir, 'ctags')
     config = File.join(config.motiondir, 'data', 'bridgesupport-ctags.cfg')
     sh "#{ctags} --options=\"#{config}\" #{bs_files.map { |x| '"' + x + '"' }.join(' ')}"


### PR DESCRIPTION
Looks good to have (especially when combined with an automatic way to run `rake ctags` as code is saved or gets committed, but that's outside the scope).
