### PR TITLE
When building, compile .strings files in resources/ into binary plist instead of copying them verbatim.

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -516,7 +516,7 @@ EOS
     end
 
     def should_compile_to_binary_plist?(res_path)
-      File.extname(res_path.split('/').last) == '.strings'
+      File.extname(res_path) == '.strings'
     end
 
     def compile_resource_to_binary_plist(path)


### PR DESCRIPTION
Related to https://groups.google.com/d/msg/rubymotion/dTMzDPp2IUo/IgTplWdYt-YJ.

The commit compiles _every_ .strings file within resources/ and other inner directories, not checking only for en.lproj, etc. I'm not sure if this is a correct assumption.
