### PR TITLE
Fail fast and show an error if no spec files are found

### DIFF
--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -278,6 +278,9 @@ module Motion; module Project
           files_filter.map! { |x| File.exist?(x) ? File.expand_path(x) : x }
           specs.delete_if { |x| [File.expand_path(x), File.basename(x, '.rb'), File.basename(x, '_spec.rb')].none? { |p| files_filter.include?(p) } }
         end
+
+        App.fail "There are no spec files to run. Place your spec files in your project under the `spec` directory." if specs.empty?
+
         spec_core_files + helpers + specs
       end
     end


### PR DESCRIPTION
If there are no spec files, when running `rake spec`, the app will crash at runtime with this error message:

```
2014-05-12 19:06:02.608 App[69351:70b] *** Terminating app due to uncaught exception 'NoMethodError', reason: 'spec.rb:476:in `current_context': undefined method `[]' for nil:NilClass (NoMethodError)
```

Since new Rubymotion projects come with a `main_spec.rb` sample spec, this will not be a common problem. However this can be very helpful when using the `files` env variable to select only some spec files (I run into this all the time).

The previous error will still happen if we have empty spec files. This could be solved by checking at runtime if `@contexts` is empty in `spec.rb`. But I'm not sure if this is recommended/necessary.
