### PR TITLE
Don't crash when provisioning_profile needs file expansion 

### DIFF
--- a/lib/motion/project/template/ios/builder.rb
+++ b/lib/motion/project/template/ios/builder.rb
@@ -95,7 +95,7 @@ PLIST
       # Copy the provisioning profile.
       bundle_provision = File.join(bundle_path, "embedded.mobileprovision")
       App.info 'Create', bundle_provision
-      FileUtils.cp config.provisioning_profile, bundle_provision
+      FileUtils.cp File.expand_path(config.provisioning_profile), bundle_provision
 
       # Codesign.
       codesign_cmd = "CODESIGN_ALLOCATE=\"#{File.join(config.platform_dir(platform), 'Developer/usr/bin/codesign_allocate')}\" /usr/bin/codesign"


### PR DESCRIPTION
allow relative paths like `~/Dropbox/Frontback/Provisioning/my_dev_profile.mobileprovision`
