### PR TITLE
Add option to skip dsym generation

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -485,10 +485,12 @@ EOS
       end
 
       # Generate dSYM.
-      dsym_path = config.app_bundle_dsym(platform)
-      if !File.exist?(dsym_path) or File.mtime(main_exec) > File.mtime(dsym_path)
-        App.info "Create", dsym_path
-        sh "/usr/bin/dsymutil \"#{main_exec}\" -o \"#{dsym_path}\""
+      unless ENV["skip_dsym"]
+        dsym_path = config.app_bundle_dsym(platform)
+        if !File.exist?(dsym_path) or File.mtime(main_exec) > File.mtime(dsym_path)
+          App.info "Create", dsym_path
+          sh "/usr/bin/dsymutil \"#{main_exec}\" -o \"#{dsym_path}\""
+        end
       end
 
       # Strip all symbols. Only in distribution mode.


### PR DESCRIPTION
Creating the .dsym file currently adds 15 seconds to the build time of one of my projects.
Given that I don't always need symbols information, it seems unnecessary to always generate this file.
