### PR TITLE
Allows a user to define a :prebuid rake task

### DIFF
--- a/lib/motion/project/app.rb
+++ b/lib/motion/project/app.rb
@@ -75,6 +75,9 @@ module Motion; module Project
       end
 
       def build(platform, opts={})
+        # Allows the user to define a :prebuild task
+        Rake::Task[:prebuild].invoke if Rake::Task.task_defined?(:prebuild)
+
         builder.build(config, platform, opts)
       end
 


### PR DESCRIPTION
This gets invoked before the build process.

Inspired by my difficulty in running commands before the build process, i wrote a blog post about it... I wanted to make it easier.

http://blog.markrickert.me/prepending-the-default-rubymotion-build-task

So now in the rakefile you can define a `:prebuild` task and it will run before the build process.

``` ruby
desc "Prebuild Process"
task :prebuild do
  # Do something awesome and automated!
end
```

Thoughts?
