### PR TITLE
Codesign embedded_frameworks for OS X too (was: [OS X] Add codesign_frameworks to configuration. Use it to specify which frameworks to codesign)

### DIFF
--- a/lib/motion/project/template/osx/builder.rb
+++ b/lib/motion/project/template/osx/builder.rb
@@ -50,7 +50,7 @@ module Motion; module Project
         if File.mtime(config.project_file) > File.mtime(framework_path) \
             or !system("/usr/bin/codesign --verify \"#{framework_path}\" >& /dev/null")
           App.info 'Codesign', framework_path
-          sh "/usr/bin/codesign --force --sign \"#{config.codesign_certificate}\" --preserve-metadata=\"identifier,entitlements\" \"#{framework_path}\""
+          sh "/usr/bin/codesign --force --sign \"#{config.codesign_certificate}\" --preserve-metadata=\"identifier,entitlements,resource-rules\" \"#{framework_path}\""
         end
       end
 


### PR DESCRIPTION
Use it like this:

```
app.codesign_frameworks << 'Sparkle.framework'
```

Relevant:
- [TN2206 OS X Code Signing In Depth – Signing Frameworks](https://developer.apple.com/library/mac/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG13)
- http://furbo.org/2013/10/17/code-signing-and-mavericks/
