### PR TITLE
Add simulator_target and simulator_device_name in Rakefile

### DIFF
--- a/lib/motion/project/template/ios.rb
+++ b/lib/motion/project/template/ios.rb
@@ -80,7 +80,8 @@ desc "Run the simulator"
 task :simulator do
   deployment_target = Motion::Util::Version.new(App.config.deployment_target)
 
-  target = ENV['target']
+  target = App.config.simulator_target
+  target = ENV['target'] if ENV['target']
   if target && Motion::Util::Version.new(target) < deployment_target
     App.fail "It is not possible to simulate an SDK version (#{target}) " \
              "lower than the app's deployment target (#{deployment_target})"
@@ -165,7 +166,8 @@ END
     end
   end
 
-  device_name = ENV["device_name"]
+  device_name = App.config.simulator_device_name
+  device_name = ENV["device_name"] if ENV["device_name"]
   simulate_device = App.config.device_family_string(device_name, family_int, target, retina)
 
   # Launch the simulator.

--- a/lib/motion/project/template/ios/config.rb
+++ b/lib/motion/project/template/ios/config.rb
@@ -32,7 +32,7 @@ module Motion; module Project;
 
     variable :device_family, :interface_orientations, :background_modes,
       :status_bar_style, :icons, :prerendered_icon, :fonts, :seed_id,
-      :provisioning_profile, :manifest_assets
+      :provisioning_profile, :manifest_assets, :simulator_target, :simulator_device_name
 
     def initialize(project_dir, build_mode)
       super


### PR DESCRIPTION
It's really painfull to add device_name and target for any rake command.

This PR add simulator_target and simulator_device_name in the app.config for easy defaults
