### PR TITLE
Disable *motion* gem names by default

### DIFF
--- a/lib/motion/command/create.rb
+++ b/lib/motion/command/create.rb
@@ -65,6 +65,11 @@ module Motion; class Command
     def validate!
       super
       help! "A name for the new project is required." unless @app_name
+
+      if @template == "gem" && !ENV['MOTION_ALLOW_MOTION'] && @app_name.downcase.include?("motion")
+        help! "Sorry, names including *motion* are not allowed.\nIf you still want to use this name, set the\nMOTION_ALLOW_MOTION environment variable and try again."
+      end
+      
       # TODO This needs to take into account external templates (e.g. from git
       #      or a local path.)
       #unless self.class.all_templates.include?(@template)


### PR DESCRIPTION
Yes, ironic that the creator of “ProMotion” and co-creator of
“MotionKit” would suggest this, but those were the old days when it was
still cool. ;-)

![screen shot 2014-10-16 at 12 37 47 pm](https://cloud.githubusercontent.com/assets/1479215/4669274/a140812c-556c-11e4-9535-09fcb8452c7f.png)
