### PR TITLE
[Android] Add optional <application> attributes via Rakefile

### DIFF
--- a/lib/motion/project/template/android.rb
+++ b/lib/motion/project/template/android.rb
@@ -66,8 +66,31 @@ EOS
   end
   # Custom manifest entries.
   App.config.manifest_xml_lines(nil).each { |line| android_manifest_txt << "\t" + line + "\n" }
+  # <application> optional attributes
+  opt_application_attributes = []
+  opt_attributes_list = [:icon, :application_class, :allowTaskReparenting, :allowBackup, :backupAgent, :banner,
+    :description, :enabled, :hasCode, :hardwareAccelerated,
+    :isGame, :killAfterRestore, :largeHeap, :logo,
+    :manageSpaceActivity, :permission, :persistent, :process,
+    :restoreAnyVersion, :requiredAccountType, :restrictedAccountType,
+    :supportsRtl, :taskAffinity, :testOnly, :theme, :uiOptions, :vmSafeMode]
+    
+    opt_attributes_list.each do |opt_attr|
+    unless App.config.send(opt_attr).nil?
+      case opt_attr
+      when :icon, :banner, :logo
+        opt_application_attributes << "android:#{opt_attr.to_s}=\"@drawable/" + App.config.send(opt_attr) + '"'
+      when :application_class
+        opt_application_attributes << 'android:name="' + App.config.application_class + '"'
+      when :description
+        opt_application_attributes << 'android:description=@string/"' + App.config.description + '"'
+      else
+        opt_application_attributes << "android:#{opt_attr.to_s}=\"" + App.config.send(opt_attr) + '"'
+      end
+    end
+  end
   android_manifest_txt << <<EOS
-  <application android:label="#{App.config.name}" android:debuggable="#{App.config.development? ? 'true' : 'false'}" #{App.config.icon ? ('android:icon="@drawable/' + App.config.icon + '"') : ''} #{App.config.application_class ? ('android:name="' + App.config.application_class + '"') : ''}>
+  <application android:label="#{App.config.name}" android:debuggable="#{App.config.development? ? 'true' : 'false'}" #{opt_application_attributes.join(" ")}>
 EOS
   App.config.manifest_xml_lines('application').each { |line| android_manifest_txt << "\t\t" + line + "\n" }
   # Main activity.

--- a/lib/motion/project/template/android/config.rb
+++ b/lib/motion/project/template/android/config.rb
@@ -30,7 +30,12 @@ module Motion; module Project;
     variable :sdk_path, :ndk_path, :avd_config, :package, :main_activity,
       :sub_activities, :api_version, :target_api_version, :arch, :assets_dirs,
       :icon, :logs_components, :version_code, :version_name, :permissions,
-      :features, :services, :application_class
+      :features, :services, :application_class, :allowTaskReparenting,
+      :allowBackup, :backupAgent, :banner, :description, :enabled,
+      :hasCode, :hardwareAccelerated, :isGame, :killAfterRestore, :largeHeap,
+      :logo, :manageSpaceActivity, :permission, :persistent, :process,
+      :restoreAnyVersion, :requiredAccountType, :restrictedAccountType,
+      :supportsRtl, :taskAffinity, :testOnly, :theme, :uiOptions, :vmSafeMode
 
     def initialize(project_dir, build_mode)
       super


### PR DESCRIPTION
Hi everyone, 

I couldn't find a way to pass all the `<application>` attributes from the `Rakefile`(or any other way) to the `AndroidManifest.xml`. Looks like the only settable ones are icon and 'application_class'(translated to name) right now.

This enables all the possibles `<application>` attributes to be set on the `Rakefile` and passed to the `AndroidManifest.xml`. I've removed the 'debuggable' and 'label' from the list, as those are treated differently.

I've added more lines of code than I wanted, but couldn't find a better way.

Anyway, this is more a 'Did I miss something?' than a 'This needs to be merged' kind of PR.

thanks!
