### PR TITLE
[Android] Add optional <application> attributes via Rakefile

### DIFF
--- a/lib/motion/project/template/android.rb
+++ b/lib/motion/project/template/android.rb
@@ -66,8 +66,11 @@ EOS
   end
   # Custom manifest entries.
   App.config.manifest_xml_lines(nil).each { |line| android_manifest_txt << "\t" + line + "\n" }
+  # <application> attributes
+  App.config.icon ? (App.config.manifest[:application]['android:icon'] = '@drawable/' + App.config.icon) : nil
+  App.config.application_class ? (App.config.manifest[:application]['android:name'] = App.config.application_class) : nil
   android_manifest_txt << <<EOS
-  <application android:label="#{App.config.name}" android:debuggable="#{App.config.development? ? 'true' : 'false'}" #{App.config.icon ? ('android:icon="@drawable/' + App.config.icon + '"') : ''} #{App.config.application_class ? ('android:name="' + App.config.application_class + '"') : ''}>
+  <application android:label="#{App.config.name}" android:debuggable="#{App.config.development? ? 'true' : 'false'}" #{ App.config.manifest[:application].map { |k,v| "#{k}=\"#{v}\""  }.join(" ") }>
 EOS
   App.config.manifest_xml_lines('application').each { |line| android_manifest_txt << "\t\t" + line + "\n" }
   # Main activity.

--- a/lib/motion/project/template/android/config.rb
+++ b/lib/motion/project/template/android/config.rb
@@ -30,7 +30,7 @@ module Motion; module Project;
     variable :sdk_path, :ndk_path, :avd_config, :package, :main_activity,
       :sub_activities, :api_version, :target_api_version, :arch, :assets_dirs,
       :icon, :logs_components, :version_code, :version_name, :permissions,
-      :features, :services, :application_class
+      :features, :services, :application_class, :manifest
 
     def initialize(project_dir, build_mode)
       super
@@ -49,6 +49,7 @@ module Motion; module Project;
       @version_code = '1'
       @version_name = '1.0'
       @application_class = nil
+      @manifest = {:application => {}}
 
       if path = ENV['RUBYMOTION_ANDROID_SDK']
         @sdk_path = File.expand_path(path)


### PR DESCRIPTION
This enables all the possibles <application> attributes to be set on the Rakefile and passed to the AndroidManifest.xml using the format:

``` ruby
app.manifest[:application]['android:logo'] = "@drawable/logo"
```
This addresses the suggestions from #181 and #180 

close #180 