### PR TITLE
Always add application-identifier in Entitlements.plist for iOS so they work correctly for TestFlight builds and `rake device`

### DIFF
--- a/lib/motion/project/template/ios/config.rb
+++ b/lib/motion/project/template/ios/config.rb
@@ -190,9 +190,8 @@ module Motion; module Project;
 
     def entitlements_data
       dict = entitlements
-      if distribution_mode
-        dict['application-identifier'] ||= seed_id + '.' + identifier
-      else
+      dict['application-identifier'] ||= seed_id + '.' + identifier
+      unless distribution_mode
         # Required for gdb.
         dict['get-task-allow'] = true if dict['get-task-allow'].nil?
       end


### PR DESCRIPTION
Not sure what has changed, but iOS is demanding application-identifier to be present for device builds (via `rake device` and testflight)