### PR TITLE
[Android] Make sure all Ruby file paths are flattened into single Array

### DIFF
--- a/lib/motion/project/template/android.rb
+++ b/lib/motion/project/template/android.rb
@@ -151,6 +151,7 @@ EOS
   objs_build_dir = File.join(app_build_dir, 'obj', 'local', App.config.armeabi_directory_name)
   kernel_bc = App.config.kernel_path
   ruby_objs_changed = false
+  App.config.files.flatten!
   ((App.config.spec_mode ? App.config.spec_files : []) + App.config.files).each do |ruby_path|
     bc_path = File.join(objs_build_dir, File.expand_path(ruby_path) + '.bc')
     init_func = "MREP_" + `/bin/echo \"#{File.expand_path(bc_path)}\" | /usr/bin/openssl sha1`.strip


### PR DESCRIPTION
I was trying to integrate the motion_print gem into an Android app and got this error during the build:

```
rake aborted!
TypeError: no implicit conversion of Array into String
/Library/RubyMotion/lib/motion/project/template/android.rb:156:in `expand_path'
/Library/RubyMotion/lib/motion/project/template/android.rb:156:in `block (2 levels) in <top (required)>'
/Library/RubyMotion/lib/motion/project/template/android.rb:155:in `each'
/Library/RubyMotion/lib/motion/project/template/android.rb:155:in `block in <top (required)>'
Tasks: TOP => device => build
```

It looks like motion_print is exposing its file paths as an Array, and that doesn't get correctly flattened with the other file paths in the RubyMotion Android template. Since motion_print works fine in iOS, I'm assuming that this is a bug on the Android side. 

Calling `flatten` on `App.config.files` does the trick, though I'm not sure if that's the best overall solution.

Here's a sample repo that illustrates the problem (along with a couple of other issues that I'll file as separate support requests): https://github.com/darinwilson/rma-testing/tree/master/gem_integration