### PR TITLE
[Android] Fix to re-generate classes.dex when resource files are updated

### DIFF
--- a/lib/motion/project/template/android.rb
+++ b/lib/motion/project/template/android.rb
@@ -363,7 +363,6 @@ EOS
   end
 
   # Compile java files.
-  classes_changed = false
   vendored_jars = App.config.vendored_projects.map { |x| x[:jar] }
   vendored_jars += [File.join(App.config.versioned_datadir, 'rubymotion.jar')]
   classes_dir = File.join(app_build_dir, 'classes')


### PR DESCRIPTION
Currently,  `build` rake task doesn`t  re-generate `classes.dex` when files in `resources` directory are updated, I have to manually delete `classes.dex` before building `.apk` file to see changes on device or emulator.

I think that `classes.dex` should be re-generated and there is an issue in `lib/motion/project/template/android.rb`.

In `build` task, `classes_changed` variable:

* is initialized to `false` on line 106
* is set to `true` when `R.java` is re-compiled on line 123
* is set to `false` again on line 366
* stays `false` between line 379 and 391 because `R` class name is excluded on line 379

Then, it won`t match any of conditions on line 396-399. Thus, `rake build` won`t re-generate `classes.dex` when  files in `resources` directory are updated.

I think that the issue is that line 366 is setting `classes_changed` to false unconditionally. This line should be removed.

Thank you for your consideration.