### PR TITLE
[Android] Fix to bulid files in order that is specified by files_dependencies

### DIFF
--- a/lib/motion/project/template/android.rb
+++ b/lib/motion/project/template/android.rb
@@ -133,7 +133,7 @@ task :build do
   objs_build_dir = File.join(app_build_dir, 'obj', 'local', App.config.armeabi_directory_name)
   kernel_bc = App.config.kernel_path
   ruby_objs_changed = false
-  ((App.config.spec_mode ? App.config.spec_files : []) + App.config.files).each do |ruby_path|
+  ((App.config.spec_mode ? App.config.spec_files : []) + App.config.ordered_build_files).each do |ruby_path|
     ruby_obj = File.join(objs_build_dir, File.expand_path(ruby_path) + '.o')
     init_func = "MREP_" + `/bin/echo \"#{File.expand_path(ruby_obj)}\" | /usr/bin/openssl sha1`.strip
     if !File.exist?(ruby_obj) \


### PR DESCRIPTION
Currently, `build` task in Android doesn't build files in order that is specified by `file_dependencies`. This PR should fix this issue.

When I create project like following:

```
$ motion create --template=android SampleDependencyAndroid
    Create SampleDependencyAndroid
    Create SampleDependencyAndroid/.gitignore
    Create SampleDependencyAndroid/app/main_activity.rb
    Create SampleDependencyAndroid/Gemfile
    Create SampleDependencyAndroid/Rakefile
    Create SampleDependencyAndroid/spec/main_spec.rb
$ cd SampleDependencyAndroid
$ cat >> app/a_module.rb
module AModule
  def a; 'a'; end
end
$ cat >> app/z_module.rb
module ZModule
  def z; 'z'; end
end
$ cat app/main_activity.rb
class MainActivity < Android::App::Activity
  include AModule
  include ZModule

  def onCreate(savedInstanceState)
    super

    puts a
    puts z
  end
end
$ cat Rakefile
# -*- coding: utf-8 -*-
$:.unshift("/Library/RubyMotion/lib")
require 'motion/project/template/android'

begin
  require 'bundler'
  Bundler.require
rescue LoadError
end

Motion::Project::App.setup do |app|
  # Use `rake config' to see complete project settings.
  app.name = 'SampleDependencyAndroid'
  app.files_dependencies 'app/main_activity.rb' => ['app/a_module.rb', 'app/z_module.rb']
end
```

Currently, when I build and run on emulator, I get error.

```
$ rake emulator
    Create ./build/Development-19/AndroidManifest.xml
   Compile ./app/a_module.rb
   Compile ./app/main_activity.rb
   Compile ./app/z_module.rb
    Create ./build/Development-19/lib/armeabi/libpayload.so
    Create ./build/Development-19/lib/armeabi/gdbserver
    Create ./build/Development-19/lib/armeabi/gdb.setup
Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8
    Create ./build/Development-19/classes.dex
Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8
    Create ./build/Development-19/SampleDependencyAndroid.apk
      Sign ./build/Development-19/SampleDependencyAndroid.apk
     Align ./build/Development-19/SampleDependencyAndroid.apk
   Install ./build/Development-19/SampleDependencyAndroid.apk
1404 KB/s (784145 bytes in 0.545s)
     Start com.yourcompany.sampledependencyandroid/.MainActivity
--------- beginning of /dev/log/system
--------- beginning of /dev/log/main
E/com/yourcompany/sampledependencyandroid( 1314): Exception raised: TypeError: false is not a Module
E/com/yourcompany/sampledependencyandroid( 1314): Uncaught exception when initializing `main_activity.rb.o' scope -- aborting
E/AndroidRuntime( 1314): FATAL EXCEPTION: main
E/AndroidRuntime( 1314): Process: com.yourcompany.sampledependencyandroid, PID: 1314
E/AndroidRuntime( 1314): java.lang.UnsatisfiedLinkError: JNI_ERR returned from JNI_OnLoad in "/data/app-lib/com.yourcompany.sampledependencyandroid-1/libpayload.so"
E/AndroidRuntime( 1314):        at java.lang.Runtime.loadLibrary(Runtime.java:364)
E/AndroidRuntime( 1314):        at java.lang.System.loadLibrary(System.java:526)
E/AndroidRuntime( 1314):        at com.yourcompany.sampledependencyandroid.MainActivity.<clinit>(MainActivity.java:10)
E/AndroidRuntime( 1314):        at java.lang.Class.newInstanceImpl(Native Method)
E/AndroidRuntime( 1314):        at java.lang.Class.newInstance(Class.java:1208)
E/AndroidRuntime( 1314):        at android.app.Instrumentation.newActivity(Instrumentation.java:1061)
E/AndroidRuntime( 1314):        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2112)
E/AndroidRuntime( 1314):        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2245)
E/AndroidRuntime( 1314):        at android.app.ActivityThread.access$800(ActivityThread.java:135)
E/AndroidRuntime( 1314):        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1196)
E/AndroidRuntime( 1314):        at android.os.Handler.dispatchMessage(Handler.java:102)
E/AndroidRuntime( 1314):        at android.os.Looper.loop(Looper.java:136)
E/AndroidRuntime( 1314):        at android.app.ActivityThread.main(ActivityThread.java:5017)
E/AndroidRuntime( 1314):        at java.lang.reflect.Method.invokeNative(Native Method)
E/AndroidRuntime( 1314):        at java.lang.reflect.Method.invoke(Method.java:515)
E/AndroidRuntime( 1314):        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:779)
E/AndroidRuntime( 1314):        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:595)
E/AndroidRuntime( 1314):        at dalvik.system.NativeStart.main(Native Method)

^Crake aborted!
Interrupt:
/Library/RubyMotion/lib/motion/project/template/android.rb:555:in `run_apk'
/Library/RubyMotion/lib/motion/project/template/android.rb:568:in `block (2 levels) in <top (required)>'
Tasks: TOP => emulator => emulator:start
(See full trace by running task with --trace)
```

With fix in this PR, it runs fine.

```
$ rake emulator
    Create ./build/Development-19/AndroidManifest.xml
   Compile ./app/a_module.rb
   Compile ./app/z_module.rb
   Compile ./app/main_activity.rb
    Create ./build/Development-19/lib/armeabi/libpayload.so
    Create ./build/Development-19/lib/armeabi/gdbserver
    Create ./build/Development-19/lib/armeabi/gdb.setup
Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8
    Create ./build/Development-19/classes.dex
Picked up _JAVA_OPTIONS: -Dfile.encoding=UTF-8
    Create ./build/Development-19/SampleDependencyAndroid.apk
      Sign ./build/Development-19/SampleDependencyAndroid.apk
     Align ./build/Development-19/SampleDependencyAndroid.apk
   Install ./build/Development-19/SampleDependencyAndroid.apk
1381 KB/s (784183 bytes in 0.554s)
     Start com.yourcompany.sampledependencyandroid/.MainActivity
--------- beginning of /dev/log/main
--------- beginning of /dev/log/system
I/com/yourcompany/sampledependencyandroid( 1362): a
I/com/yourcompany/sampledependencyandroid( 1362): z
^Crake aborted!
Interrupt:
/Library/RubyMotion/lib/motion/project/template/android.rb:555:in `run_apk'
/Library/RubyMotion/lib/motion/project/template/android.rb:568:in `block (2 levels) in <top (required)>'
Tasks: TOP => emulator => emulator:start
(See full trace by running task with --trace)
```

Thank you for your consideration.