### PR TITLE
[Android] Fix NameError when running spec on Android platform (rubymotion 3.7)

### DIFF
--- a/lib/motion/project/template/android.rb
+++ b/lib/motion/project/template/android.rb
@@ -163,8 +163,8 @@ task :build do
   ruby_objs = app_objs = parallel.objects
   spec_objs = []
   if App.config.spec_mode
-    app_objs = objs[0...App.config.ordered_build_files.size]
-    spec_objs = objs[-(App.config.spec_files.size)..-1]
+    app_objs = ruby_objs[0...App.config.ordered_build_files.size]
+    spec_objs = ruby_objs[-(App.config.spec_files.size)..-1]
   end
 
   FileUtils.touch(objs_build_dir) if ruby_objs_changed


### PR DESCRIPTION
This should fix error when running `rake spec` on Android platform with RubyMotion version 3.7.

```
$ rake spec:emulator
    Create ./build/Testing-19/AndroidManifest.xml
   Compile ./app/main_activity.rb
   Compile ./spec/main_spec.rb
   Compile /Library/RubyMotion/lib/motion/spec.rb
rake aborted!
NameError: undefined local variable or method `objs' for main:Object
/Library/RubyMotion/lib/motion/project/template/android.rb:166:in `block in <top (required)>'
/Library/RubyMotion/lib/motion/project/template/android.rb:633:in `block (2 levels) in <top (required)>'
Tasks: TOP => emulator => build
(See full trace by running task with --trace)
```