### PR TITLE
Fix ctags task

### DIFF
--- a/lib/motion/project/xcode_config.rb
+++ b/lib/motion/project/xcode_config.rb
@@ -677,6 +677,7 @@ EOS
     end
 
     def ctags_files
+      config = App.config
       ctags_files = bridgesupport_files
       ctags_files += config.vendor_projects.map { |p| Dir.glob(File.join(p.path, '*.bridgesupport')) }.flatten
       ctags_files += config.files.flatten


### PR DESCRIPTION
Not sure why this is breaking with:

```
rake aborted!
NameError: undefined local variable or method `config' for #<Motion::Project::IOSConfig:0x007ff3eb638940>
/Library/RubyMotion/lib/motion/project/xcode_config.rb:681:in `ctags_files'
/Library/RubyMotion/lib/motion/project.rb:76:in `block in <top (required)>'
/Users/kylefang/.rvm/gems/ruby-2.1.3/bin/ruby_executable_hooks:15:in `eval'
/Users/kylefang/.rvm/gems/ruby-2.1.3/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => ctags
(See full trace by running task with --trace)
```
