### PR TITLE
Add support for optional_features in android

### DIFF
--- a/lib/motion/project/template/android.rb
+++ b/lib/motion/project/template/android.rb
@@ -129,6 +129,11 @@ task :build do
     App.config.manifest.child('application').add_child('uses-feature', 'android:name' => "#{feature}")
   end
 
+  # optional_features
+  App.config.optional_features.each do |feature|
+    App.config.manifest.child('application').add_child('uses-feature', 'android:name' => "#{feature}", 'android:required' => 'false')
+  end
+
   # sub activities
   (App.config.sub_activities.uniq - [App.config.main_activity]).each do |activity|
 

--- a/lib/motion/project/template/android/config.rb
+++ b/lib/motion/project/template/android/config.rb
@@ -95,7 +95,8 @@ module Motion; module Project;
     variable :sdk_path, :ndk_path, :package, :main_activity, :sub_activities,
       :api_version, :target_api_version, :arch, :assets_dirs, :icon,
       :logs_components, :version_code, :version_name, :permissions, :features,
-      :services, :application_class, :manifest, :theme, :support_libraries
+      :optional_features, :services, :application_class, :manifest, :theme,
+      :support_libraries
 
     # Non-public.
     attr_accessor :vm_debug_logs, :libs
@@ -109,6 +110,7 @@ module Motion; module Project;
       @vendored_projects = []
       @permissions = []
       @features = []
+      @optional_features = []
       @services = []
       @manifest_entries = {}
       @release_keystore_path = nil


### PR DESCRIPTION
According to documentation we should provide a way to support `optional_features`.

Adding camera features to your manifest causes Google Play to prevent your application from being installed to devices that do not include a camera or do not support the camera features you specify.

This commit will generate the following line in the manifest when using `app.optional_features = ["android.hardware.camera"]`:

    <uses-feature android:name="android.hardware.camera" android:required="false" />
