### PR TITLE
Show info if files sent to spec are incorrect

### DIFF
--- a/lib/motion/spec.rb
+++ b/lib/motion/spec.rb
@@ -503,6 +503,9 @@ module Bacon
   end
 
   def self.current_context
+    if ENV['files'] && @contexts.nil?
+      raise "Current context not set, perhaps there is an error in the file names you provided? (#{ENV['files'].join(',')}"
+    end
     @contexts[current_context_index]
   end
 


### PR DESCRIPTION
If you run rake spec files='blah' and blah does not exist you get an
undefined method on nil in spec.rb:506.  This is an attempt to clarify
that the problem is likely that your provided pathname is incorrect.

After this patch, you get a message that can help the developer
understand the error easier. "Current context not set, perhaps there is
an error in the file names you provided? ( provided value in ENV['files'] )
