### PR TITLE
Fix crash and not responding when tapped Done in ios-photo-editing extension template

### DIFF
--- a/lib/motion/project/template/ios-photo-editing/files/app/photo_editing_view_controller.rb
+++ b/lib/motion/project/template/ios-photo-editing/files/app/photo_editing_view_controller.rb
@@ -43,7 +43,7 @@ class PhotoEditingViewController < UIViewController
 
     # Render and provide output on a background queue.
 
-    Dispatch::Queue.concurrent {
+    Dispatch::Queue.concurrent.async {
       # Create editing output from the editing input.
       output = PHContentEditingOutput.alloc.initWithContentEditingInput(self.input)
 
@@ -57,6 +57,10 @@ class PhotoEditingViewController < UIViewController
 
       # Clean up temporary files, etc.
     }
+  end
+
+  def shouldShowCancelConfirmation
+    false
   end
 
   def cancelContentEditing


### PR DESCRIPTION
Fix:

* Crash when launch
* Nothing happens when tapped Done