### PR TITLE
Remove CFBundleResourceSpecification from WatchKit App

### DIFF
--- a/lib/motion/project/target/extension_target.rb
+++ b/lib/motion/project/target/extension_target.rb
@@ -51,7 +51,7 @@ module Motion; module Project
       if watchapp_dir && Dir.exists?(watchapp_dir)
         entitlements = File.join(watchapp_dir, "Entitlements.plist")
         codesign_cmd = "CODESIGN_ALLOCATE=\"#{File.join(@config.platform_dir(platform), 'Developer/usr/bin/codesign_allocate')}\" /usr/bin/codesign"
-        sh "#{codesign_cmd} -f -s \"#{@config.codesign_certificate}\" --resource-rules=\"#{resource_rules_plist}\" --entitlements \"#{entitlements}\" \"#{watchapp_dir}\""
+        sh "#{codesign_cmd} -f -s \"#{@config.codesign_certificate}\" --entitlements \"#{entitlements}\" \"#{watchapp_dir}\""
       end
 
       # Codesign executable

--- a/lib/motion/project/template/ios-watch-extension-config.rb
+++ b/lib/motion/project/template/ios-watch-extension-config.rb
@@ -170,7 +170,7 @@ EOS
       #
       def merged_info_plist(platform)
         plist = super
-        plist['UIDeviceFamily'] << 4 # Probably means Apple Watch device?
+        plist['UIDeviceFamily'] = [4] # Probably means Apple Watch device?
         plist['WKWatchKitApp'] = true
         plist['WKCompanionAppBundleIdentifier'] = ENV['RM_TARGET_HOST_APP_IDENTIFIER']
         plist.delete('UIBackgroundModes')

--- a/lib/motion/project/template/ios-watch-extension-config.rb
+++ b/lib/motion/project/template/ios-watch-extension-config.rb
@@ -175,6 +175,7 @@ EOS
         plist['WKCompanionAppBundleIdentifier'] = ENV['RM_TARGET_HOST_APP_IDENTIFIER']
         plist.delete('UIBackgroundModes')
         plist.delete('UIStatusBarStyle')
+        plist.delete('CFBundleResourceSpecification')
         plist
       end
 


### PR DESCRIPTION
Following an App Store submission the following response was received.

> WatchKit App.app/Info.plist' contains the key ‘CFBundleResourceSpecification’. You will need to remove that key from the Info.plist at that location, then re-submit your binary.

I hope this should fix it.