### PR TITLE
Remove WatchKit from CFBundleDisplayName

### DIFF
--- a/lib/motion/project/template/ios-watch-extension-config.rb
+++ b/lib/motion/project/template/ios-watch-extension-config.rb
@@ -141,6 +141,7 @@ EOS
         @name = ENV['RM_TARGET_HOST_APP_NAME'] + ' WatchKit App'
         @version = ENV['RM_TARGET_HOST_APP_VERSION']
         @short_version = ENV['RM_TARGET_HOST_APP_SHORT_VERSION']
+        @interface_orientations = [:portrait, :portrait_upside_down]
       end
 
       def sdk_version
@@ -170,11 +171,13 @@ EOS
       #
       def merged_info_plist(platform)
         plist = super
+        plist['CFBundleDisplayName'] = ENV['RM_TARGET_HOST_APP_NAME']
         plist['UIDeviceFamily'] = [4] # Probably means Apple Watch device?
         plist['WKWatchKitApp'] = true
         plist['WKCompanionAppBundleIdentifier'] = ENV['RM_TARGET_HOST_APP_IDENTIFIER']
         plist.delete('UIBackgroundModes')
         plist.delete('UIStatusBarStyle')
+        plist.delete('UIAppFonts')
         plist.delete('CFBundleResourceSpecification')
         plist
       end

--- a/lib/motion/project/template/ios-watch-extension-config.rb
+++ b/lib/motion/project/template/ios-watch-extension-config.rb
@@ -171,8 +171,8 @@ EOS
       #
       def merged_info_plist(platform)
         plist = super
+        plist['UIDeviceFamily'] = (platform == 'iPhoneOS') ? [4] : plist['UIDeviceFamily'] << 4 # Probably means Apple Watch device?
         plist['CFBundleDisplayName'] = ENV['RM_TARGET_HOST_APP_NAME']
-        plist['UIDeviceFamily'] = [4] # Probably means Apple Watch device?
         plist['WKWatchKitApp'] = true
         plist['WKCompanionAppBundleIdentifier'] = ENV['RM_TARGET_HOST_APP_IDENTIFIER']
         plist.delete('UIBackgroundModes')


### PR DESCRIPTION
Following a rejection, this changes the WatchKit app's `CFBundleDisplayName` to equal the parent app's name. I changed this and not `@name` in the config as that's needed for the correct Bundle and Executable names. Additionally changes a few other plist values similar to an Xcode build. Have tested this in both the simulator and a device this time :wink: Rejection details below:

>We noticed that your app name to be displayed on the App Store and the name displayed on Apple Watch do not sufficiently match. Specifically, the displayed app name on Apple Watch includes "WatchKit."
>Please revise your app name displayed on the Apple Watch to remove all "WatchKit" references.
>To change the app name, modify the CFBundleDisplayName key in your Info.plist