### PR TITLE
specify adb target device determined by device_id method

### DIFF
--- a/lib/motion/project/template/android.rb
+++ b/lib/motion/project/template/android.rb
@@ -583,7 +583,7 @@ def adb_mode_flag(mode)
     when :emulator
       '-e'
     when :device
-      '-d'
+      "-s #{device_id}"
     else
       raise
   end


### PR DESCRIPTION
(which may be connected via TCP) instead of adb choosing the first USB device

see http://community.rubymotion.com/t/bug-android-debug-bridge-adb-on-osx-is-flaky-rubymotion-on-adb-is-even-flakier/598