### PR TITLE
Add option to embed provisioning profile on OS X

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -487,6 +487,8 @@ EOS
         end
       end
 
+      embed_provisioning_profile(config, bundle_path)
+
       # Optional support for #eval (OSX-only).
       if config.respond_to?(:eval_support) and config.eval_support
         repl_dylib_path = File.join(datadir, '..', 'librubymotion-repl.dylib')
@@ -552,6 +554,10 @@ EOS
         App.info 'Copy', res_path
         FileUtils.cp_r(res_path, dest_path)
       end
+    end
+
+    def embed_provisioning_profile(config, bundle)
+
     end
 
     def profile(config, platform, config_plist)

--- a/lib/motion/project/template/osx/builder.rb
+++ b/lib/motion/project/template/osx/builder.rb
@@ -104,5 +104,13 @@ module Motion; module Project
         sh(command)
       end
     end
+
+    def embed_provisioning_profile(config, bundle)
+      if config.provisioning_profile
+        bundle_provision = File.join(bundle, "embedded.provisionprofile")
+        App.info 'Copy', bundle_provision
+        FileUtils.cp config.provisioning_profile, bundle_provision
+      end
+    end
   end
 end; end

--- a/lib/motion/project/template/osx/config.rb
+++ b/lib/motion/project/template/osx/config.rb
@@ -33,7 +33,7 @@ module Motion; module Project;
     variable :icon, :copyright, :category,
         :embedded_frameworks, :external_frameworks,
         :codesign_for_development, :codesign_for_release,
-        :eval_support
+        :eval_support, :provisioning_profile
 
     def initialize(project_dir, build_mode)
       super
@@ -44,6 +44,7 @@ module Motion; module Project;
       @codesign_for_development = false
       @codesign_for_release = true
       @eval_support = false
+      @provisioning_profile = nil
     end
 
     def platforms; ['MacOSX']; end


### PR DESCRIPTION
This adds a `config.provisioning_profile` option (named to be consistent with iOS config option, despite it being called a "provisionprofile" on OS X) for OS X projects, which will embed the specified Mac Developer provisioning profile in the bundle.