### PR TITLE
Add missing background_modes

### DIFF
--- a/lib/motion/project/template/ios/config.rb
+++ b/lib/motion/project/template/ios/config.rb
@@ -357,9 +357,12 @@ module Motion; module Project;
           when :audio then 'audio'
           when :location then 'location'
           when :voip then 'voip'
+          when :fetch then 'fetch'
+          when :remote_notification then 'remote-notification'
           when :newsstand_content then 'newsstand-content'
           when :external_accessory then 'external-accessory'
           when :bluetooth_central then 'bluetooth-central'
+          when :bluetooth_peripheral then 'bluetooth-peripheral'
           else
             App.fail "Unknown background_modes value: `#{mode}'"
         end


### PR DESCRIPTION
_This is kind of a W.I.P. since I am not able to test this until monday. I'm running El Capitan at the moment and won't have access to a machine running Yosemite till monday._

_ This resolves issue #219 _

This pull request adds the options listed below. While a user could reference missing background modes like the following:

``` ruby
app.info_plist['UIBackgroundModes'] = [ 'bluetooth-central', 'bluetooth-peripheral' , 'my-missing-background-mode'] 
```

I think it's cleaner to reference it as the other already present background modes :smile: 

Now you should be able to reference bluetooth-peripheral together with audio like:

``` ruby
app.background_modes = [:audio, :bluetooth_peripheral] 
```
- Add fetch  (iOS 7 and later)
  The app requires new content from the network on a regular basis. When
  it is convenient to do so, the system launches or resumes the app in
  the background and gives it a small amount of time to download any new
  content.
- Add remote-notification (iOS 7 and later)
  The app uses remote notifications as a signal that there is new content available for download. When a remote notification arrives, the system launches or resumes the app in the background and gives it a small amount of time to download the new content.
- Add bluetooth-peripheral (iOS 6 and later)
  The app uses the CoreBluetooth framework to communicate in peripheral mode with a Bluetooth accessory. The system will alert the user to the potential privacy implications of apps with this key set.

I came across the following URL 
https://github.com/HipByte/RubyMotion/blob/master/lib/motion/project/template/ios.rb#L177
Should I also update the message to state that you can also set background_mode via the app.background_modes way?
