### PR TITLE
add support for platform name in filename

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -101,6 +101,16 @@ module Motion; module Project;
         end
       end
 
+      # filter cross platform files
+      if config.cross_platform_mode
+        excluded_platforms = (Config::SUPPORTED_TEMPLATES - [config.template]).map(&:to_s)
+        config.files.each do |file|
+          if excluded_platforms.any? { |excluded| file.include?(excluded) }
+            config.files.delete(file)
+          end
+        end
+      end
+
       # Build object files.
       objs_build_dir = File.join(build_dir, 'objs')
       FileUtils.mkdir_p(objs_build_dir)

--- a/lib/motion/project/config.rb
+++ b/lib/motion/project/config.rb
@@ -31,6 +31,8 @@ module Motion; module Project
   class Config
     include Rake::DSL if defined?(Rake) && Rake.const_defined?(:DSL)
 
+    SUPPORTED_TEMPLATES = [:ios, :android, :osx]
+
     VARS = []
 
     def self.variable(*syms)
@@ -58,7 +60,7 @@ module Motion; module Project
     # Internal only.
     attr_accessor :build_mode, :spec_mode, :distribution_mode, :dependencies,
       :template, :detect_dependencies, :exclude_from_detect_dependencies,
-      :opt_level, :custom_init_funcs
+      :opt_level, :custom_init_funcs, :cross_platform_mode
 
     ConfigTemplates = {}
 
@@ -89,6 +91,7 @@ module Motion; module Project
       @detect_dependencies = true
       @exclude_from_detect_dependencies = []
       @custom_init_funcs = []
+      @cross_platform_mode = false
     end
 
     def osx_host_version


### PR DESCRIPTION
Based on http://hipbyte.myjetbrains.com/youtrack/issue/RM-902 only difference being variable name is `cross_platform_mode` instead of `cross_platform`