### PR TITLE
Force dir to end with trailing /, so dir="resources" wouldn't match  path="resources-adhoc/img.png"

### DIFF
--- a/lib/motion/project/builder.rb
+++ b/lib/motion/project/builder.rb
@@ -544,10 +544,10 @@ EOS
     end
 
     def path_on_resources_dirs(dirs, path)
-      dir = dirs.each do |dir|
-        break dir if path =~ /^#{dir}/
+      dir = File.dirname(path)
+      if dirs.include?(dir)
+        path = path.sub(/^#{dir}\/*/, '')
       end
-      path = path.sub(/^#{dir}\/*/, '') if dir
       path
     end
 


### PR DESCRIPTION
So `dir="resources"` wouldn't match  `path="resources-adhoc/img.png"`.

Useful to support Rakefile like this:

    if env == 'adhoc'
      app.resources_dirs << './resources-adhoc'
    end

Without the patch, `img.png` gets written as `-adhoc/img.png`.