### PR TITLE
Added MainMenu.xib to OSX template to resolve compilation warnings

### DIFF
--- a/lib/motion/project/template/osx/files/Rakefile.erb
+++ b/lib/motion/project/template/osx/files/Rakefile.erb
@@ -10,5 +10,6 @@ end
 
 Motion::Project::App.setup do |app|
   # Use `rake config' to see complete project settings.
+  app.info_plist['NSMainNibFile'] = 'MainMenu'
   app.name = '<%= name %>'
 end

--- a/lib/motion/project/template/osx/files/resources/MainMenu.xib
+++ b/lib/motion/project/template/osx/files/resources/MainMenu.xib
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="NSApplication"/>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
+        <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6"/>
+    </objects>
+</document>


### PR DESCRIPTION
Newly generated OSX projects have initial compilation warnings.

```
Failed to connect (colorGridView) outlet from (NSApplication) to (NSColorPickerGridView): missing setter or instance variable
Failed to connect (view) outlet from (NSApplication) to (NSColorPickerGridView): missing setter or instance variable
```

I added the necessary MainMenu.xib file and updated the info_plist via the Rakefile in the OSX template.
