### PR TITLE
Fixed view method to have correct output

### DIFF
--- a/lib/motion/project/template/ios/spec-helpers/ui.rb
+++ b/lib/motion/project/template/ios/spec-helpers/ui.rb
@@ -293,13 +293,13 @@ module Bacon
       def view(label)
         return label if label.is_a?(UIView)
         UIApplication.sharedApplication.keyWindow.viewByName(label) ||
-          raise(Bacon::Error.new(:error, "Unable to find a view with label `#{label}'"))
+          raise(Bacon::Error.new(:errors, "Unable to find a view with label `#{label}'"))
       end
 
       def views(view_class)
         views = UIApplication.sharedApplication.keyWindow.viewsByClass(view_class)
         if views.empty?
-          raise(Bacon::Error.new(:error, "Unable to find any view of class `#{view_class.name}'"))
+          raise(Bacon::Error.new(:errors, "Unable to find any view of class `#{view_class.name}'"))
         end
         views
       end


### PR DESCRIPTION
Hello!

I noticed that when using the view method of ui.rb inside a test, if the method didn't find the view I wanted, the resulting log in console said 0 failures, 0 errors even tho it failed.

I found that the key of the Error getting raised should be either :errors or :failed to have it printed (but not :error). I leave here the fix.

Thanks!
