### PR TITLE
Run only some specs

### DIFF
--- a/lib/motion/spec.rb
+++ b/lib/motion/spec.rb
@@ -19,7 +19,7 @@ module Bacon
     raise NameError, "no such context: #{name.inspect}"
   }
 
-  RestrictName    = //  unless defined? RestrictName
+  RestrictName    = ENV['filter'] ? Regexp.new(ENV['filter']) : //  unless defined? RestrictName
   RestrictContext = //  unless defined? RestrictContext
 
   Backtraces = true  unless defined? Backtraces


### PR DESCRIPTION
I've seen that Bacon has way to filter specs to run by matching a regexp against test names.
I've modified RubyMotion's spec.rb to support this by passing 'filter' as ENV variable when running rake spec.

E.g rake spec filter='test user controller'

Cheers!
