### PR TITLE
Functional tests don't remove window correctly when an Alert is displayed

### DIFF
--- a/lib/motion/project/template/ios/spec-helpers/ui.rb
+++ b/lib/motion/project/template/ios/spec-helpers/ui.rb
@@ -197,6 +197,7 @@ module Bacon
           end
 
           # Remove window and ensure a new one will be created on the next run.
+          app.keyWindow.hidden = true
           window.removeFromSuperview
           proper_wait(0.3) # give objects a chance to do their cleanup, otherwise sometimes a segfault will occur
           @window = nil


### PR DESCRIPTION
I've noticed that if an alert is displayed during a test, the window that ios displays its placed on top of the actual window and it never ever gets away, even tho there is logic in ui.rb to, every time someone sets self.controller, remove the window and place a new one. 

Setting the keyWindow to be hidden just before removing the actual window, makes the trick!