### PR TITLE
Legalize generated Android package names so they don't contain '-'

### DIFF
--- a/lib/motion/project/template/android/config.rb
+++ b/lib/motion/project/template/android/config.rb
@@ -221,7 +221,8 @@ module Motion; module Project
     end
 
     def package
-      @package ||= 'com.yourcompany' + '.' + name.downcase.gsub(/\s/, '')
+      #Legalize package names so they don't include '-'
+      @package ||= 'com.yourcompany' + '.' + name.downcase.gsub(/\s/, '').gsub('-', '_')
     end
 
     def package_path


### PR DESCRIPTION
To prevent this error when building an app with the '-' character in its name:

    ./build/Development-23/AndroidManifest.xml:2: Tag <manifest> attribute package has invalid character '-'.

See http://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html