### PR TITLE
When code signing, a connection to the Apple time servers is required.

### DIFF
--- a/lib/motion/project/template/osx/builder.rb
+++ b/lib/motion/project/template/osx/builder.rb
@@ -107,6 +107,7 @@ module Motion; module Project
         command = "/usr/bin/codesign --force --sign '#{config.codesign_certificate}' "
         command << "--deep " if deep
         command << "--entitlements '#{entitlements_path}' " if entitlements_path
+        command << "--timestamp=none " if config.codesign_disable_timestamp
         command << "'#{bundle}'"
         sh(command)
       end

--- a/lib/motion/project/xcode_config.rb
+++ b/lib/motion/project/xcode_config.rb
@@ -32,7 +32,7 @@ module Motion; module Project
   class XcodeConfig < Config
     variable :xcode_dir, :sdk_version, :deployment_target, :frameworks,
              :weak_frameworks, :embedded_frameworks, :external_frameworks, :framework_search_paths,
-             :libs, :identifier, :codesign_certificate, :short_version, :entitlements, :delegate_class, :embed_dsym,
+             :libs, :identifier, :codesign_certificate, :codesign_disable_timestamp, :short_version, :entitlements, :delegate_class, :embed_dsym,
              :version
 
     def initialize(project_dir, build_mode)
@@ -53,6 +53,7 @@ module Motion; module Project
       @embed_dsym = (development? ? true : false)
       @vendor_projects = []
       @version = '1.0'
+      @codesign_disable_timestamp = false
     end
 
     def xcode_dir=(xcode_dir)


### PR DESCRIPTION
If you’re building without an internet connection (airplane, train,
etc), then it can be impossible to build.  Particularly when you need
to use code signing during development.  Implemented the
`codesign_disable_timestamp` config variable to pass the
`—timestamp=none` flag to the `codesign` executable.  Defaults
to false.  Only for macOS at the moment.